### PR TITLE
set driver when subscribe

### DIFF
--- a/probe/src/probe/main.cpp
+++ b/probe/src/probe/main.cpp
@@ -122,6 +122,7 @@ int main(int argc, char** argv) {
 
         try {
             inspector->open("");
+            inspector->clear_eventmask();
         }
         catch (const sinsp_exception &e) {
             open_success = false;

--- a/probe/src/probe/publisher/publisher.h
+++ b/probe/src/probe/publisher/publisher.h
@@ -19,7 +19,7 @@ typedef void * Socket;
 
 class selector {
 public:
-    selector();
+    selector(sinsp *inspector);
     bool select(uint16_t type, Category category);
     void parse(const google::protobuf::RepeatedPtrField<::kindling::Label> &field);
 
@@ -28,6 +28,7 @@ private:
     map<string, ppm_event_type> m_events;
     map<string, Category> m_categories;
     Category get_category(string category);
+    sinsp *m_inspector;
 };
 
 // publish kindling event

--- a/probe/src/userspace/libscap/scap.c
+++ b/probe/src/userspace/libscap/scap.c
@@ -1658,25 +1658,7 @@ static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t event
 
 	if(handle->m_bpf)
 	{
-	    switch(op) {
-	    case PPM_IOCTL_MASK_FILL_EVENTS:
-	        scap_bpf_fill_eventmask(handle);
-	        break;
-        case PPM_IOCTL_MASK_ZERO_EVENTS:
-            scap_bpf_clear_eventmask(handle);
-            break;
-        case PPM_IOCTL_MASK_SET_EVENT:
-            scap_bpf_set_eventmask(handle, event_id);
-            break;
-        case PPM_IOCTL_MASK_UNSET_EVENT:
-            scap_bpf_unset_eventmask(handle, event_id);
-            break;
-
-            default:
-            snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on bpf");
-            ASSERT(false);
-            return SCAP_FAILURE;
-	    }
+        return scap_bpf_handle_eventmask(handle, op, event_id);
 	}
 	else
 	{

--- a/probe/src/userspace/libscap/scap_bpf.h
+++ b/probe/src/userspace/libscap/scap_bpf.h
@@ -45,16 +45,13 @@ int32_t scap_bpf_disable_dynamic_snaplen(scap_t* handle);
 int32_t scap_bpf_enable_page_faults(scap_t* handle);
 int32_t scap_bpf_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio);
 int32_t scap_bpf_stop_dropping_mode(scap_t* handle);
-int32_t scap_bpf_fill_eventmask(scap_t* handle);
-int32_t scap_bpf_clear_eventmask(scap_t* handle);
-int32_t scap_bpf_set_eventmask(scap_t* handle, uint32_t event_id);
-int32_t scap_bpf_unset_eventmask(scap_t* handle, uint32_t event_id);
 int32_t scap_bpf_enable_tracers_capture(scap_t* handle);
 int32_t scap_bpf_enable_skb_capture(scap_t *handle, const char *ifname);
 int32_t scap_bpf_disable_skb_capture(scap_t *handle);
 struct ppm_proclist_info *scap_bpf_get_threadlist(scap_t *handle);
 int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats);
 int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret);
+int32_t scap_bpf_handle_eventmask(scap_t* handle, uint32_t op, uint32_t event_id);
 
 static inline scap_evt *scap_bpf_evt_from_perf_sample(void *evt)
 {


### PR DESCRIPTION
These commits preserve the essential events so that the driver will not miss events for modifying state, ensuring the application works normally. To improve performance partially,  using eventmask to drop events which we don't subscribe. The process of notifying driver will be done when subscribing.

#26 for area/probe