### PR TITLE
fix: set syscall enter event if only subscribing syscall exit event

### DIFF
--- a/probe/src/probe/publisher/publisher.cpp
+++ b/probe/src/probe/publisher/publisher.cpp
@@ -322,5 +322,8 @@ void selector::parse(const google::protobuf::RepeatedPtrField<::kindling::Label>
     // notify kernel, set eventmask
     for (auto it : *m_labels) {
         m_inspector->set_eventmask(it.first);
+        if (!PPME_IS_ENTER(it.first)) {
+            m_inspector->set_eventmask(it.first - 1);
+        }
     }
 }


### PR DESCRIPTION
Something wrong with #36, like syscall exit event write will be filtered out. This commit fixes it.

Signed-off-by: sanyangji <songyujie@zju.edu.cn>