### PR TITLE
Fix bug that always return 0 when the input string is in IPv4 format

### DIFF
--- a/collector/metadata/conntracker/utils.go
+++ b/collector/metadata/conntracker/utils.go
@@ -17,7 +17,7 @@ func IPToUInt32(ip net.IP) uint32 {
 
 func StringToUint32(ip string) uint32 {
 	bytes := strings.Split(ip, ".")
-	if len(bytes) <= 4 {
+	if len(bytes) < 4 {
 		return 0
 	}
 	b0, _ := strconv.Atoi(bytes[0])

--- a/collector/metadata/conntracker/utils_test.go
+++ b/collector/metadata/conntracker/utils_test.go
@@ -1,0 +1,47 @@
+package conntracker
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIPToUInt32(t *testing.T) {
+	type args struct {
+		ip net.IP
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint32
+	}{
+		{name: "", args: args{ip: net.IPv4(1, 2, 3, 4)}, want: 67305985},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IPToUInt32(tt.args.ip); got != tt.want {
+				t.Errorf("IPToUInt32() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringToUint32(t *testing.T) {
+	type args struct {
+		ip string
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint32
+	}{
+		{name: "normal", args: args{ip: "1.2.3.4"}, want: 67305985},
+		{name: "illegal", args: args{ip: "1.2"}, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringToUint32(tt.args.ip); got != tt.want {
+				t.Errorf("StringToUint32() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```go
func StringToUint32(ip string) uint32 {
	bytes := strings.Split(ip, ".")
        // This line will make the result always be zero when the input IP string is in IPv4 fomat
	if len(bytes) <= 4 {
		return 0
	}
	b0, _ := strconv.Atoi(bytes[0])
	b1, _ := strconv.Atoi(bytes[1])
	b2, _ := strconv.Atoi(bytes[2])
	b3, _ := strconv.Atoi(bytes[3])

	return uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
}
```
fix #44
