### PR TITLE
Fix Parse kafaka request failed by index out of range

### DIFF
--- a/collector/analyzer/network/protocol/kafka/kafka_request.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request.go
@@ -33,7 +33,7 @@ func parseRequest() protocol.ParsePkgFn {
 
 		message.ReadInt32(8, &correlationId)
 		message.ReadInt16(12, &clientIdLength)
-		if correlationId < 0 {
+		if correlationId < 0 || clientIdLength < 0 {
 			return false, true
 		}
 		var offset = int(clientIdLength) + 14

--- a/collector/analyzer/network/protocol/protocol_parser.go
+++ b/collector/analyzer/network/protocol/protocol_parser.go
@@ -122,6 +122,9 @@ func (message *PayloadMessage) ReadUInt16(offset int) (complete bool, value uint
 }
 
 func (message *PayloadMessage) ReadInt16(offset int, v *int16) (toOffset int, err error) {
+	if offset < -1 {
+		return -1, ErrMessageInvalid
+	}
 	if offset+2 >= len(message.Data) {
 		return -1, ErrMessageShort
 	}


### PR DESCRIPTION
The clientLength is negative that caused index out of range.