### PR TITLE
Store the topology metric whose src_ip is from external namespace

### DIFF
--- a/collector/application/testdata/kindling-collector-config.yaml
+++ b/collector/application/testdata/kindling-collector-config.yaml
@@ -60,6 +60,7 @@ processors:
   kindlingformatprocessor:
     need_trace_as_metric: true
     need_pod_detail: true
+    store_external_src_ip: true
   nodemetricprocessor:
 
 exporters:

--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -95,7 +95,7 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 	} else {
 		labelMap.AddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
 		labelMap.AddStringValue(constlabels.SrcNode, p.localNodeName)
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
 	}
 	// add metadata for dst
 	dstIp := labelMap.GetStringValue(constlabels.DstIp)
@@ -133,8 +133,10 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 		if nodeName, ok := p.metadata.GetNodeNameByIp(dstIp); ok {
 			labelMap.AddStringValue(constlabels.DstNodeIp, dstIp)
 			labelMap.AddStringValue(constlabels.DstNode, nodeName)
+			labelMap.AddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
+		} else {
+			labelMap.AddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
 		}
-		labelMap.AddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
 	}
 }
 
@@ -151,8 +153,10 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForServerLabel(labelMap *model.Attr
 		if nodeName, ok := p.metadata.GetNodeNameByIp(srcIp); ok {
 			labelMap.AddStringValue(constlabels.SrcNodeIp, srcIp)
 			labelMap.AddStringValue(constlabels.SrcNode, nodeName)
+			labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		} else {
+			labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
 		}
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
 	}
 	containerId := labelMap.GetStringValue(constlabels.ContainerId)
 	labelMap.AddStringValue(constlabels.DstContainerId, containerId)
@@ -165,7 +169,7 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForServerLabel(labelMap *model.Attr
 	} else {
 		labelMap.AddStringValue(constlabels.DstNodeIp, p.localNodeIp)
 		labelMap.AddStringValue(constlabels.DstNode, p.localNodeName)
-		labelMap.AddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
+		labelMap.AddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
 	}
 }
 
@@ -199,8 +203,11 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpSRC(labelMap *model.AttributeM
 		addPodMetaInfoLabelSRC(labelMap, srcPodInfo)
 		return
 	}
-
-	labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+	if _, ok := p.metadata.GetNodeNameByIp(srcIp); ok {
+		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+	} else {
+		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+	}
 }
 
 func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeMap) {
@@ -241,8 +248,11 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 		addPodMetaInfoLabelDST(labelMap, dstPodInfo)
 		return
 	}
-
-	labelMap.AddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
+	if _, ok := p.metadata.GetNodeNameByIp(dstIp); ok {
+		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+	} else {
+		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+	}
 }
 
 func addContainerMetaInfoLabelSRC(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {

--- a/collector/consumer/processor/kindlingformatprocessor/config.go
+++ b/collector/consumer/processor/kindlingformatprocessor/config.go
@@ -1,6 +1,7 @@
 package kindlingformatprocessor
 
 type Config struct {
-	NeedTraceAsMetric bool `mapstructure:"need_trace_as_metric"`
-	NeedPodDetail     bool `mapstructure:"need_pod_detail"`
+	NeedTraceAsMetric  bool `mapstructure:"need_trace_as_metric"`
+	NeedPodDetail      bool `mapstructure:"need_pod_detail"`
+	StoreExternalSrcIP bool `mapstructure:"store_external_src_ip"`
 }

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
@@ -123,7 +123,7 @@ func TopologyTraceK8sInfo(cfg *Config, g *gauges) {
 }
 
 func TopologyK8sInfo(cfg *Config, g *gauges) {
-	if cfg.NeedPodDetail || constlabels.IsNamespaceNotFound(g.Labels.GetStringValue(constlabels.DstNamespace)) {
+	if cfg.NeedPodDetail {
 		TopologyTraceK8sInfo(cfg, g)
 	} else {
 		g.targetLabels.AddStringValue(constlabels.SrcNamespace, g.Labels.GetStringValue(constlabels.SrcNamespace))
@@ -135,6 +135,11 @@ func TopologyK8sInfo(cfg *Config, g *gauges) {
 		g.targetLabels.AddStringValue(constlabels.DstWorkloadKind, g.Labels.GetStringValue(constlabels.DstWorkloadKind))
 		g.targetLabels.AddStringValue(constlabels.DstWorkloadName, g.Labels.GetStringValue(constlabels.DstWorkloadName))
 		g.targetLabels.AddStringValue(constlabels.DstService, g.Labels.GetStringValue(constlabels.DstService))
+
+		if constlabels.IsNamespaceNotFound(g.Labels.GetStringValue(constlabels.DstNamespace)) {
+			g.targetLabels.AddStringValue(constlabels.DstNode, g.Labels.GetStringValue(constlabels.DstNode))
+			g.targetLabels.AddStringValue(constlabels.DstPod, g.Labels.GetStringValue(constlabels.DstPod))
+		}
 	}
 }
 

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
@@ -123,7 +123,7 @@ func TopologyTraceK8sInfo(cfg *Config, g *gauges) {
 }
 
 func TopologyK8sInfo(cfg *Config, g *gauges) {
-	if cfg.NeedPodDetail || g.Labels.GetStringValue(constlabels.DstNamespace) == constlabels.ExternalClusterNamespace {
+	if cfg.NeedPodDetail || constlabels.IsNamespaceNotFound(g.Labels.GetStringValue(constlabels.DstNamespace)) {
 		TopologyTraceK8sInfo(cfg, g)
 	} else {
 		g.targetLabels.AddStringValue(constlabels.SrcNamespace, g.Labels.GetStringValue(constlabels.SrcNamespace))
@@ -160,7 +160,7 @@ func TopologyTraceInstanceInfo(cfg *Config, g *gauges) {
 func TopologyInstanceInfo(cfg *Config, g *gauges) {
 	if cfg.NeedPodDetail {
 		TopologyTraceInstanceInfo(cfg, g)
-	} else if g.Labels.GetStringValue(constlabels.DstNamespace) == constlabels.ExternalClusterNamespace {
+	} else if constlabels.IsNamespaceNotFound(g.Labels.GetStringValue(constlabels.DstNamespace)) {
 		DstInstanceInfo(cfg, g)
 	}
 }

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
@@ -53,11 +53,12 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 			srcNamespace := gaugeGroup.Labels.GetStringValue(constlabels.SrcNamespace)
 			if srcNamespace == constlabels.ExternalClusterNamespace {
 				// Use data from server-side to generate a topology metric.
+				externalGaugeGroup := newGauges(gaugeGroup)
 				// Here we have to modify the field "IsServer" to generate the metric.
-				common.Labels.AddBoolValue(constlabels.IsServer, false)
-				metricErr2 = r.nextConsumer.Consume(common.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo, TopologyProtocolInfo))
+				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, false)
+				metricErr2 = r.nextConsumer.Consume(externalGaugeGroup.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo, TopologyProtocolInfo))
 				// In case of using the original data later, we reset the field "IsServer".
-				common.Labels.AddBoolValue(constlabels.IsServer, true)
+				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, true)
 			}
 		}
 		return multierr.Combine(traceErr, metricErr, metricErr2)

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
@@ -52,7 +52,7 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 		if r.cfg.StoreExternalSrcIP {
 			srcNamespace := gaugeGroup.Labels.GetStringValue(constlabels.SrcNamespace)
 			if srcNamespace == constlabels.ExternalClusterNamespace {
-				// Use data from server-side to generate a topology metric.
+				// Use data from server-side to generate a topology metric only when the namespace is EXTERNAL.
 				externalGaugeGroup := newGauges(gaugeGroup)
 				// Here we have to modify the field "IsServer" to generate the metric.
 				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, false)

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
@@ -48,7 +48,19 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 		//protocol := newGauges(gaugeGroup)
 		//protocolErr := r.nextConsumer.Consume(protocol.Process(r.cfg, ProtocolDetailMetricName, ServiceInstanceInfo, ServiceK8sInfo, ProtocolDetailInfo))
 		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, ServiceInstanceInfo, ServiceK8sInfo, ServiceProtocolInfo))
-		return multierr.Combine(traceErr, metricErr)
+		var metricErr2 error
+		if r.cfg.StoreExternalSrcIP {
+			srcNamespace := gaugeGroup.Labels.GetStringValue(constlabels.SrcNamespace)
+			if srcNamespace == constlabels.ExternalClusterNamespace {
+				// Use data from server-side to generate a topology metric.
+				// Here we have to modify the field "IsServer" to generate the metric.
+				common.Labels.AddBoolValue(constlabels.IsServer, false)
+				metricErr2 = r.nextConsumer.Consume(common.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo, TopologyProtocolInfo))
+				// In case of using the original data later, we reset the field "IsServer".
+				common.Labels.AddBoolValue(constlabels.IsServer, true)
+			}
+		}
+		return multierr.Combine(traceErr, metricErr, metricErr2)
 	} else {
 		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo, SrcDockerInfo, TopologyProtocolInfo))
 		return multierr.Combine(traceErr, metricErr)

--- a/collector/deploy/kindling-collector-config.yml
+++ b/collector/deploy/kindling-collector-config.yml
@@ -71,6 +71,7 @@ processors:
   kindlingformatprocessor:
     need_trace_as_metric: true
     need_pod_detail: true
+    store_external_src_ip: true
   nodemetricprocessor:
 
 

--- a/collector/model/constlabels/const.go
+++ b/collector/model/constlabels/const.go
@@ -62,9 +62,14 @@ const (
 	RequestProcessingStatus = "request_processing_status"
 	ResponseRspxferStatus   = "response_rspxfer_status"
 
-	ExternalClusterNamespace = "EXTERNAL"
+	ExternalClusterNamespace = "NOT_FOUND_EXTERNAL"
+	InternalClusterNamespace = "NOT_FOUND_INTERNAL"
 )
 
 const (
 	STR_EMPTY = ""
 )
+
+func IsNamespaceNotFound(namespace string) bool {
+	return namespace == ExternalClusterNamespace || namespace == InternalClusterNamespace
+}


### PR DESCRIPTION
Generate a topology gauge when the data from the server-side contains an external src IP.

This PR will close #46 