### PR TITLE
Use poststart to solve the problem that the collector cannot receive events after the probe restarts

### DIFF
--- a/deploy/kindling-deploy.yml
+++ b/deploy/kindling-deploy.yml
@@ -19,6 +19,12 @@ spec:
       - name: kindling-probe
         image: kindlingproject/kindling-probe:latest
         imagePullPolicy: Always
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - sh
+                - /pl/post_start.sh
         args:
         - --v=1
         - --minloglevel=0

--- a/probe/deploy/BUILD.bazel
+++ b/probe/deploy/BUILD.bazel
@@ -1,6 +1,6 @@
 filegroup(
     name = "scripts",
-    srcs = ["docker-entrypoint.sh","kindling-probe-loader","gdb_print.sh"],
+    srcs = ["docker-entrypoint.sh","kindling-probe-loader","gdb_print.sh","post_start.sh"],
     visibility = ["//visibility:public"],
 )
 

--- a/probe/deploy/post_start.sh
+++ b/probe/deploy/post_start.sh
@@ -1,0 +1,4 @@
+if [ ! -n "$(ps -ef|grep kindling-collector |awk '$0 !~/grep/ {print $1}' |tr -s '\n' ' ')" ]; then
+	echo "no such process"
+else
+	kill -9 $(ps -ef|grep kindling-collector |awk '$0 !~/grep/ {print $1}' |tr -s '\n' ' ')


### PR DESCRIPTION
#34 
https://github.com/Kindling-project/kindling/issues/34
This is a temporary solution. Restart the collector when you restart the probe
//todo: Design detection mechanism to ensure the availability of UNIX domain socket

Signed-off-by: jundizhou <jundizhou@harmonycloud.cn>