### PR TITLE
Use sync.Pool to reuse objects when networkanalyzer generates a new request

### DIFF
--- a/collector/analyzer/network/gauge_pool.go
+++ b/collector/analyzer/network/gauge_pool.go
@@ -1,0 +1,39 @@
+package network
+
+import (
+	"github.com/Kindling-project/kindling/collector/model"
+	"github.com/Kindling-project/kindling/collector/model/constvalues"
+	"sync"
+	"time"
+)
+
+func createGaugeGroup() interface{} {
+	values := []*model.Gauge{
+		{Name: constvalues.ConnectTime, Value: 0},
+		{Name: constvalues.RequestSentTime, Value: 0},
+		{Name: constvalues.WaitingTtfbTime, Value: 0},
+		{Name: constvalues.ContentDownloadTime, Value: 0},
+		{Name: constvalues.RequestTotalTime, Value: 0},
+		{Name: constvalues.RequestIo, Value: 0},
+		{Name: constvalues.ResponseIo, Value: 0},
+	}
+	gaugeGroup := model.NewGaugeGroup("", model.NewAttributeMap(), uint64(time.Now().UnixNano()), values...)
+	return gaugeGroup
+}
+
+type GaugeGroupPool struct {
+	pool *sync.Pool
+}
+
+func NewGaugePool() *GaugeGroupPool {
+	return &GaugeGroupPool{pool: &sync.Pool{New: createGaugeGroup}}
+}
+
+func (p *GaugeGroupPool) Get() *model.GaugeGroup {
+	return p.pool.Get().(*model.GaugeGroup)
+}
+
+func (p *GaugeGroupPool) Free(gaugeGroup *model.GaugeGroup) {
+	gaugeGroup.Reset()
+	p.pool.Put(gaugeGroup)
+}

--- a/collector/analyzer/network/network_analyzer.go
+++ b/collector/analyzer/network/network_analyzer.go
@@ -37,6 +37,7 @@ type NetworkAnalyzer struct {
 	protocolMap      map[string]*protocol.ProtocolParser
 	parsers          []*protocol.ProtocolParser
 
+	gaugeGroupPool *GaugeGroupPool
 	requestMonitor sync.Map
 	telemetry      *component.TelemetryTools
 }
@@ -44,9 +45,10 @@ type NetworkAnalyzer struct {
 func NewNetworkAnalyzer(cfg interface{}, telemetry *component.TelemetryTools, consumers []consumer.Consumer) analyzer.Analyzer {
 	config, _ := cfg.(*Config)
 	return &NetworkAnalyzer{
-		cfg:           config,
-		nextConsumers: consumers,
-		telemetry:     telemetry,
+		cfg:            config,
+		gaugeGroupPool: NewGaugePool(),
+		nextConsumers:  consumers,
+		telemetry:      telemetry,
 	}
 }
 
@@ -278,6 +280,7 @@ func (na *NetworkAnalyzer) distributeTraceMetric(oldPairs *messagePairs, newPair
 		for _, nexConsumer := range na.nextConsumers {
 			nexConsumer.Consume(record)
 		}
+		na.gaugeGroupPool.Free(record)
 	}
 	return nil
 }
@@ -430,29 +433,23 @@ func (na *NetworkAnalyzer) parseProtocol(mps *messagePairs, parser *protocol.Pro
 
 func (na *NetworkAnalyzer) getConnectFailRecords(mps *messagePairs, protocol string) []*model.GaugeGroup {
 	evt := mps.connects.event
-	return []*model.GaugeGroup{
-		{
-			Values: []model.Gauge{
-				{Name: constvalues.ConnectTime, Value: int64(mps.connects.getDuration())},
-				{Name: constvalues.RequestTotalTime, Value: int64(mps.connects.getDuration())},
-			},
-			Labels: model.NewAttributeMapWithValues(map[string]model.AttributeValue{
-				constlabels.Pid:         model.NewIntValue(int64(evt.GetPid())),
-				constlabels.SrcIp:       model.NewStringValue(evt.GetSip()),
-				constlabels.DstIp:       model.NewStringValue(evt.GetDip()),
-				constlabels.SrcPort:     model.NewIntValue(int64(evt.GetSport())),
-				constlabels.DstPort:     model.NewIntValue(int64(evt.GetDport())),
-				constlabels.DnatIp:      model.NewStringValue(constlabels.STR_EMPTY),
-				constlabels.DnatPort:    model.NewIntValue(-1),
-				constlabels.ContainerId: model.NewStringValue(evt.GetContainerId()[:]),
-				constlabels.IsError:     model.NewBoolValue(true),
-				constlabels.ErrorType:   model.NewIntValue(int64(constlabels.ConnectFail)),
-				constlabels.IsSlow:      model.NewBoolValue(false),
-				constlabels.IsServer:    model.NewBoolValue(evt.GetCtx().GetFdInfo().Role),
-			}),
-			Timestamp: evt.GetStartTime(),
-		},
-	}
+	ret := na.gaugeGroupPool.Get()
+	ret.UpdateAddGauge(constvalues.ConnectTime, int64(mps.connects.getDuration()))
+	ret.UpdateAddGauge(constvalues.RequestTotalTime, int64(mps.connects.getDuration()))
+	ret.Labels.UpdateAddIntValue(constlabels.Pid, int64(evt.GetPid()))
+	ret.Labels.UpdateAddStringValue(constlabels.SrcIp, evt.GetSip())
+	ret.Labels.UpdateAddStringValue(constlabels.DstIp, evt.GetDip())
+	ret.Labels.UpdateAddIntValue(constlabels.SrcPort, int64(evt.GetSport()))
+	ret.Labels.UpdateAddIntValue(constlabels.DstPort, int64(evt.GetDport()))
+	ret.Labels.UpdateAddStringValue(constlabels.DnatIp, constlabels.STR_EMPTY)
+	ret.Labels.UpdateAddIntValue(constlabels.DnatPort, -1)
+	ret.Labels.UpdateAddStringValue(constlabels.ContainerId, evt.GetContainerId())
+	ret.Labels.UpdateAddBoolValue(constlabels.IsError, true)
+	ret.Labels.UpdateAddIntValue(constlabels.ErrorType, int64(constlabels.ConnectFail))
+	ret.Labels.UpdateAddBoolValue(constlabels.IsSlow, false)
+	ret.Labels.UpdateAddBoolValue(constlabels.IsServer, evt.GetCtx().GetFdInfo().Role)
+	ret.Timestamp = evt.GetStartTime()
+	return []*model.GaugeGroup{ret}
 }
 
 func (na *NetworkAnalyzer) getRecords(mps *messagePairs, protocol string, attributes *model.AttributeMap) []*model.GaugeGroup {
@@ -463,100 +460,89 @@ func (na *NetworkAnalyzer) getRecords(mps *messagePairs, protocol string, attrib
 		slow = na.isSlow(mps.getDuration(), protocol)
 	}
 
-	labels := model.NewAttributeMapWithValues(map[string]model.AttributeValue{
-		constlabels.Pid:         model.NewIntValue(int64(evt.GetPid())),
-		constlabels.SrcIp:       model.NewStringValue(evt.GetSip()),
-		constlabels.DstIp:       model.NewStringValue(evt.GetDip()),
-		constlabels.SrcPort:     model.NewIntValue(int64(evt.GetSport())),
-		constlabels.DstPort:     model.NewIntValue(int64(evt.GetDport())),
-		constlabels.DnatIp:      model.NewStringValue(constlabels.STR_EMPTY),
-		constlabels.DnatPort:    model.NewIntValue(-1),
-		constlabels.ContainerId: model.NewStringValue(evt.GetContainerId()[:]),
-		constlabels.IsSlow:      model.NewBoolValue(slow),
-		constlabels.IsServer:    model.NewBoolValue(evt.GetCtx().GetFdInfo().Role),
-		constlabels.Protocol:    model.NewStringValue(protocol),
-	})
+	ret := na.gaugeGroupPool.Get()
+	labels := ret.Labels
+	labels.UpdateAddIntValue(constlabels.Pid, int64(evt.GetPid()))
+	labels.UpdateAddStringValue(constlabels.SrcIp, evt.GetSip())
+	labels.UpdateAddStringValue(constlabels.DstIp, evt.GetDip())
+	labels.UpdateAddIntValue(constlabels.SrcPort, int64(evt.GetSport()))
+	labels.UpdateAddIntValue(constlabels.DstPort, int64(evt.GetDport()))
+	labels.UpdateAddStringValue(constlabels.DnatIp, constlabels.STR_EMPTY)
+	labels.UpdateAddIntValue(constlabels.DnatPort, -1)
+	labels.UpdateAddStringValue(constlabels.ContainerId, evt.GetContainerId())
+	labels.UpdateAddBoolValue(constlabels.IsError, false)
+	labels.UpdateAddIntValue(constlabels.ErrorType, int64(constlabels.NoError))
+	labels.UpdateAddBoolValue(constlabels.IsSlow, slow)
+	labels.UpdateAddBoolValue(constlabels.IsServer, evt.GetCtx().GetFdInfo().Role)
+	labels.UpdateAddStringValue(constlabels.Protocol, protocol)
 
 	labels.Merge(attributes)
-	if !labels.HasAttribute(constlabels.IsError) {
-		if mps.responses == nil {
-			labels.AddBoolValue(constlabels.IsError, true)
-			labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoResponse))
-		} else {
-			labels.AddBoolValue(constlabels.IsError, false)
-			labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoError))
-		}
+	// If no protocol error found, we check other errors
+	if !labels.GetBoolValue(constlabels.IsError) && mps.responses == nil {
+		labels.AddBoolValue(constlabels.IsError, true)
+		labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoResponse))
 	}
 
 	if nil != mps.natTuple && mps.responses != nil {
-		labels.AddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
-		labels.AddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
+		labels.UpdateAddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
+		labels.UpdateAddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
 	}
 
-	return []*model.GaugeGroup{
-		{
-			Values: []model.Gauge{
-				{Name: constvalues.ConnectTime, Value: int64(mps.getConnectDuration())},
-				{Name: constvalues.RequestSentTime, Value: mps.getSentTime()},
-				{Name: constvalues.WaitingTtfbTime, Value: mps.getWaitingTime()},
-				{Name: constvalues.ContentDownloadTime, Value: mps.getDownloadTime()},
-				{Name: constvalues.RequestTotalTime, Value: int64(mps.getConnectDuration() + mps.getDuration())},
-				{Name: constvalues.RequestIo, Value: int64(mps.getRquestSize())},
-				{Name: constvalues.ResponseIo, Value: int64(mps.getResponseSize())},
-			},
-			Labels:    labels,
-			Timestamp: evt.GetStartTime(),
-		},
-	}
+	ret.UpdateAddGauge(constvalues.ConnectTime, int64(mps.getConnectDuration()))
+	ret.UpdateAddGauge(constvalues.RequestSentTime, mps.getSentTime())
+	ret.UpdateAddGauge(constvalues.WaitingTtfbTime, mps.getWaitingTime())
+	ret.UpdateAddGauge(constvalues.ContentDownloadTime, mps.getDownloadTime())
+	ret.UpdateAddGauge(constvalues.RequestTotalTime, int64(mps.getConnectDuration()+mps.getDuration()))
+	ret.UpdateAddGauge(constvalues.RequestIo, int64(mps.getRquestSize()))
+	ret.UpdateAddGauge(constvalues.ResponseIo, int64(mps.getResponseSize()))
+
+	ret.Timestamp = evt.GetStartTime()
+
+	return []*model.GaugeGroup{ret}
 }
 
 func (na *NetworkAnalyzer) getRecord(mps *messagePairs, mp *messagePair, protocol string, attributes *model.AttributeMap) *model.GaugeGroup {
 	evt := mp.request
 
 	slow := na.isSlow(mp.getDuration(), protocol)
-	labels := model.NewAttributeMapWithValues(map[string]model.AttributeValue{
-		constlabels.Pid:         model.NewIntValue(int64(evt.GetPid())),
-		constlabels.SrcIp:       model.NewStringValue(evt.GetSip()),
-		constlabels.DstIp:       model.NewStringValue(evt.GetDip()),
-		constlabels.SrcPort:     model.NewIntValue(int64(evt.GetSport())),
-		constlabels.DstPort:     model.NewIntValue(int64(evt.GetDport())),
-		constlabels.DnatIp:      model.NewStringValue(constlabels.STR_EMPTY),
-		constlabels.DnatPort:    model.NewIntValue(-1),
-		constlabels.ContainerId: model.NewStringValue(evt.GetContainerId()[:]),
-		constlabels.IsSlow:      model.NewBoolValue(slow),
-		constlabels.IsServer:    model.NewBoolValue(evt.GetCtx().GetFdInfo().Role),
-		constlabels.Protocol:    model.NewStringValue(protocol),
-	})
+	ret := na.gaugeGroupPool.Get()
+	labels := ret.Labels
+	labels.UpdateAddIntValue(constlabels.Pid, int64(evt.GetPid()))
+	labels.UpdateAddStringValue(constlabels.SrcIp, evt.GetSip())
+	labels.UpdateAddStringValue(constlabels.DstIp, evt.GetDip())
+	labels.UpdateAddIntValue(constlabels.SrcPort, int64(evt.GetSport()))
+	labels.UpdateAddIntValue(constlabels.DstPort, int64(evt.GetDport()))
+	labels.UpdateAddStringValue(constlabels.DnatIp, constlabels.STR_EMPTY)
+	labels.UpdateAddIntValue(constlabels.DnatPort, -1)
+	labels.UpdateAddStringValue(constlabels.ContainerId, evt.GetContainerId())
+	labels.UpdateAddBoolValue(constlabels.IsError, false)
+	labels.UpdateAddIntValue(constlabels.ErrorType, int64(constlabels.NoError))
+	labels.UpdateAddBoolValue(constlabels.IsSlow, slow)
+	labels.UpdateAddBoolValue(constlabels.IsServer, evt.GetCtx().GetFdInfo().Role)
+	labels.UpdateAddStringValue(constlabels.Protocol, protocol)
 
 	labels.Merge(attributes)
-	if !labels.HasAttribute(constlabels.IsError) {
-		if mp.response == nil {
-			labels.AddBoolValue(constlabels.IsError, true)
-			labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoResponse))
-		} else {
-			labels.AddBoolValue(constlabels.IsError, false)
-			labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoError))
-		}
+	// If no protocol error found, we check other errors
+	if !labels.GetBoolValue(constlabels.IsError) && mps.responses == nil {
+		labels.AddBoolValue(constlabels.IsError, true)
+		labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoResponse))
 	}
 
 	if nil != mps.natTuple && mps.responses != nil {
-		labels.AddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
-		labels.AddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
+		labels.UpdateAddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
+		labels.UpdateAddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
 	}
 
-	return &model.GaugeGroup{
-		Values: []model.Gauge{
-			{Name: constvalues.ConnectTime, Value: 0},
-			{Name: constvalues.RequestSentTime, Value: mp.getSentTime()},
-			{Name: constvalues.WaitingTtfbTime, Value: mp.getWaitingTime()},
-			{Name: constvalues.ContentDownloadTime, Value: mp.getDownloadTime()},
-			{Name: constvalues.RequestTotalTime, Value: int64(mp.getDuration())},
-			{Name: constvalues.RequestIo, Value: int64(mp.getRquestSize())},
-			{Name: constvalues.ResponseIo, Value: int64(mp.getResponseSize())},
-		},
-		Labels:    labels,
-		Timestamp: evt.GetStartTime(),
-	}
+	ret.UpdateAddGauge(constvalues.ConnectTime, 0)
+	ret.UpdateAddGauge(constvalues.RequestSentTime, mps.getSentTime())
+	ret.UpdateAddGauge(constvalues.WaitingTtfbTime, mps.getWaitingTime())
+	ret.UpdateAddGauge(constvalues.ContentDownloadTime, mps.getDownloadTime())
+	ret.UpdateAddGauge(constvalues.RequestTotalTime, int64(mps.getDuration()))
+	ret.UpdateAddGauge(constvalues.RequestIo, int64(mps.getRquestSize()))
+	ret.UpdateAddGauge(constvalues.ResponseIo, int64(mps.getResponseSize()))
+
+	ret.Timestamp = evt.GetStartTime()
+	return ret
 }
 
 func (na *NetworkAnalyzer) isSlow(duration uint64, protocol string) bool {

--- a/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
+++ b/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
@@ -96,7 +96,7 @@ func (a *TcpMetricAnalyzer) generateRtt(event *model.KindlingEvent) (*model.Gaug
 	if rtt == 0 {
 		return nil, nil
 	}
-	gauge := model.Gauge{
+	gauge := &model.Gauge{
 		Name:  TcpRttMetricName,
 		Value: int64(rtt),
 	}
@@ -108,7 +108,7 @@ func (a *TcpMetricAnalyzer) generateRetransmit(event *model.KindlingEvent) (*mod
 	if err != nil {
 		return nil, err
 	}
-	gauge := model.Gauge{
+	gauge := &model.Gauge{
 		Name:  TcpRetransmitMetricName,
 		Value: 1,
 	}
@@ -120,7 +120,7 @@ func (a *TcpMetricAnalyzer) generateDrop(event *model.KindlingEvent) (*model.Gau
 	if err != nil {
 		return nil, err
 	}
-	gauge := model.Gauge{
+	gauge := &model.Gauge{
 		Name:  TcpDropMetricName,
 		Value: 1,
 	}

--- a/collector/analyzer/uprobeanalyzer/uprobeanalyzer.go
+++ b/collector/analyzer/uprobeanalyzer/uprobeanalyzer.go
@@ -135,15 +135,15 @@ func (a *UprobeAnalyzer) ConsumeEvent(event *model.KindlingEvent) error {
 		}))
 	}
 
-	latencyGauge := model.Gauge{
+	latencyGauge := &model.Gauge{
 		Name:  constvalues.RequestTotalTime,
 		Value: int64(latency),
 	}
-	requestIoGauge := model.Gauge{
+	requestIoGauge := &model.Gauge{
 		Name:  constvalues.RequestIo,
 		Value: int64(event.GetUserAttribute("req_body_size").GetValue().GetUintValue()),
 	}
-	responseIoGauge := model.Gauge{
+	responseIoGauge := &model.Gauge{
 		Name:  constvalues.ResponseIo,
 		Value: int64(event.GetUserAttribute("resp_body_size").GetValue().GetUintValue()),
 	}

--- a/collector/consumer/exporter/otelexporter/otelexporter.go
+++ b/collector/consumer/exporter/otelexporter/otelexporter.go
@@ -208,7 +208,7 @@ func (e *OtelExporter) Consume(gaugeGroup *model.GaugeGroup) error {
 		}
 		if metricKind == MAGaugeKind {
 			e.instrumentFactory.recordGaugeAsync(name, model.GaugeGroup{
-				Values:    []model.Gauge{value},
+				Values:    []*model.Gauge{value},
 				Labels:    gaugeGroup.Labels,
 				Timestamp: gaugeGroup.Timestamp,
 			})

--- a/collector/consumer/exporter/otelexporter/otelexporter_test.go
+++ b/collector/consumer/exporter/otelexporter/otelexporter_test.go
@@ -51,7 +51,7 @@ func makeGaugeGroup(latency int64) *model.GaugeGroup {
 		constlabels.ResponseContent: model.NewIntValue(201),
 	})
 
-	latencyGauge := model.Gauge{
+	latencyGauge := &model.Gauge{
 		Name:  "kindling_entity_request_duration_nanoseconds",
 		Value: latency,
 	}

--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -88,28 +88,28 @@ func (p *K8sMetadataProcessor) processTcpMetric(gaugeGroup *model.GaugeGroup) {
 func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.AttributeMap) {
 	// add metadata for src
 	containerId := labelMap.GetStringValue(constlabels.ContainerId)
-	labelMap.AddStringValue(constlabels.SrcContainerId, containerId)
+	labelMap.UpdateAddStringValue(constlabels.SrcContainerId, containerId)
 	resInfo, ok := p.metadata.GetByContainerId(containerId)
 	if ok {
 		addContainerMetaInfoLabelSRC(labelMap, resInfo)
 	} else {
-		labelMap.AddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
-		labelMap.AddStringValue(constlabels.SrcNode, p.localNodeName)
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
+		labelMap.UpdateAddStringValue(constlabels.SrcNode, p.localNodeName)
+		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
 	}
 	// add metadata for dst
 	dstIp := labelMap.GetStringValue(constlabels.DstIp)
 	if dstIp == loopbackIp {
-		labelMap.AddStringValue(constlabels.DstNodeIp, p.localNodeIp)
-		labelMap.AddStringValue(constlabels.DstNode, p.localNodeName)
+		labelMap.UpdateAddStringValue(constlabels.DstNodeIp, p.localNodeIp)
+		labelMap.UpdateAddStringValue(constlabels.DstNode, p.localNodeName)
 	}
 	dstPort := labelMap.GetIntValue(constlabels.DstPort)
 	// DstIp is IP of a service
 	if svcInfo, ok := p.metadata.GetServiceByIpPort(dstIp, uint32(dstPort)); ok {
-		labelMap.AddStringValue(constlabels.DstNamespace, svcInfo.Namespace)
-		labelMap.AddStringValue(constlabels.DstService, svcInfo.ServiceName)
-		labelMap.AddStringValue(constlabels.DstWorkloadKind, svcInfo.WorkloadKind)
-		labelMap.AddStringValue(constlabels.DstWorkloadName, svcInfo.WorkloadName)
+		labelMap.UpdateAddStringValue(constlabels.DstNamespace, svcInfo.Namespace)
+		labelMap.UpdateAddStringValue(constlabels.DstService, svcInfo.ServiceName)
+		labelMap.UpdateAddStringValue(constlabels.DstWorkloadKind, svcInfo.WorkloadKind)
+		labelMap.UpdateAddStringValue(constlabels.DstWorkloadName, svcInfo.WorkloadName)
 		// find podInfo using dnat_ip
 		dNatIp := labelMap.GetStringValue(constlabels.DnatIp)
 		dNatPort := labelMap.GetIntValue(constlabels.DnatPort)
@@ -120,8 +120,8 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 			} else {
 				// maybe dnat_ip is NodeIP
 				if nodeName, ok := p.metadata.GetNodeNameByIp(dNatIp); ok {
-					labelMap.AddStringValue(constlabels.DstNodeIp, dNatIp)
-					labelMap.AddStringValue(constlabels.DstNode, nodeName)
+					labelMap.UpdateAddStringValue(constlabels.DstNodeIp, dNatIp)
+					labelMap.UpdateAddStringValue(constlabels.DstNode, nodeName)
 				}
 			}
 		}
@@ -131,11 +131,11 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 	} else {
 		// DstIp is a IP from external
 		if nodeName, ok := p.metadata.GetNodeNameByIp(dstIp); ok {
-			labelMap.AddStringValue(constlabels.DstNodeIp, dstIp)
-			labelMap.AddStringValue(constlabels.DstNode, nodeName)
-			labelMap.AddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
+			labelMap.UpdateAddStringValue(constlabels.DstNodeIp, dstIp)
+			labelMap.UpdateAddStringValue(constlabels.DstNode, nodeName)
+			labelMap.UpdateAddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
 		} else {
-			labelMap.AddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
+			labelMap.UpdateAddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
 		}
 	}
 }
@@ -143,33 +143,33 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 func (p *K8sMetadataProcessor) addK8sMetaDataForServerLabel(labelMap *model.AttributeMap) {
 	srcIp := labelMap.GetStringValue(constlabels.SrcIp)
 	if srcIp == loopbackIp {
-		labelMap.AddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
-		labelMap.AddStringValue(constlabels.SrcNode, p.localNodeName)
+		labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
+		labelMap.UpdateAddStringValue(constlabels.SrcNode, p.localNodeName)
 	}
 	podInfo, ok := p.metadata.GetPodByIp(srcIp)
 	if ok {
 		addPodMetaInfoLabelSRC(labelMap, podInfo)
 	} else {
 		if nodeName, ok := p.metadata.GetNodeNameByIp(srcIp); ok {
-			labelMap.AddStringValue(constlabels.SrcNodeIp, srcIp)
-			labelMap.AddStringValue(constlabels.SrcNode, nodeName)
-			labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+			labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, srcIp)
+			labelMap.UpdateAddStringValue(constlabels.SrcNode, nodeName)
+			labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
 		} else {
-			labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+			labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
 		}
 	}
 	containerId := labelMap.GetStringValue(constlabels.ContainerId)
-	labelMap.AddStringValue(constlabels.DstContainerId, containerId)
+	labelMap.UpdateAddStringValue(constlabels.DstContainerId, containerId)
 	containerInfo, ok := p.metadata.GetByContainerId(containerId)
 	if ok {
 		addContainerMetaInfoLabelDST(labelMap, containerInfo)
 		if containerInfo.RefPodInfo.ServiceInfo != nil {
-			labelMap.AddStringValue(constlabels.DstService, containerInfo.RefPodInfo.ServiceInfo.ServiceName)
+			labelMap.UpdateAddStringValue(constlabels.DstService, containerInfo.RefPodInfo.ServiceInfo.ServiceName)
 		}
 	} else {
-		labelMap.AddStringValue(constlabels.DstNodeIp, p.localNodeIp)
-		labelMap.AddStringValue(constlabels.DstNode, p.localNodeName)
-		labelMap.AddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.DstNodeIp, p.localNodeIp)
+		labelMap.UpdateAddStringValue(constlabels.DstNode, p.localNodeName)
+		labelMap.UpdateAddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
 	}
 }
 
@@ -204,9 +204,9 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpSRC(labelMap *model.AttributeM
 		return
 	}
 	if _, ok := p.metadata.GetNodeNameByIp(srcIp); ok {
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
 	} else {
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
 	}
 }
 
@@ -221,10 +221,10 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 	dstPort := labelMap.GetIntValue(constlabels.DstPort)
 	dstSvcInfo, ok := p.metadata.GetServiceByIpPort(dstIp, uint32(dstPort))
 	if ok {
-		labelMap.AddStringValue(constlabels.DstNamespace, dstSvcInfo.Namespace)
-		labelMap.AddStringValue(constlabels.DstService, dstSvcInfo.ServiceName)
-		labelMap.AddStringValue(constlabels.DstWorkloadKind, dstSvcInfo.WorkloadKind)
-		labelMap.AddStringValue(constlabels.DstWorkloadName, dstSvcInfo.WorkloadName)
+		labelMap.UpdateAddStringValue(constlabels.DstNamespace, dstSvcInfo.Namespace)
+		labelMap.UpdateAddStringValue(constlabels.DstService, dstSvcInfo.ServiceName)
+		labelMap.UpdateAddStringValue(constlabels.DstWorkloadKind, dstSvcInfo.WorkloadKind)
+		labelMap.UpdateAddStringValue(constlabels.DstWorkloadName, dstSvcInfo.WorkloadName)
 		// find podInfo using dnat_ip
 		dNatIp := labelMap.GetStringValue(constlabels.DnatIp)
 		dNatPort := labelMap.GetIntValue(constlabels.DnatPort)
@@ -249,43 +249,43 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 		return
 	}
 	if _, ok := p.metadata.GetNodeNameByIp(dstIp); ok {
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
 	} else {
-		labelMap.AddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
 	}
 }
 
 func addContainerMetaInfoLabelSRC(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {
-	labelMap.AddStringValue(constlabels.SrcContainer, containerInfo.Name)
+	labelMap.UpdateAddStringValue(constlabels.SrcContainer, containerInfo.Name)
 	addPodMetaInfoLabelSRC(labelMap, containerInfo.RefPodInfo)
 }
 
 func addPodMetaInfoLabelSRC(labelMap *model.AttributeMap, podInfo *kubernetes.K8sPodInfo) {
-	labelMap.AddStringValue(constlabels.SrcNode, podInfo.NodeName)
-	labelMap.AddStringValue(constlabels.SrcNodeIp, podInfo.NodeAddress)
-	labelMap.AddStringValue(constlabels.SrcNamespace, podInfo.Namespace)
-	labelMap.AddStringValue(constlabels.SrcWorkloadKind, podInfo.WorkloadKind)
-	labelMap.AddStringValue(constlabels.SrcWorkloadName, podInfo.WorkloadName)
-	labelMap.AddStringValue(constlabels.SrcPod, podInfo.PodName)
-	labelMap.AddStringValue(constlabels.SrcIp, podInfo.Ip)
+	labelMap.UpdateAddStringValue(constlabels.SrcNode, podInfo.NodeName)
+	labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, podInfo.NodeAddress)
+	labelMap.UpdateAddStringValue(constlabels.SrcNamespace, podInfo.Namespace)
+	labelMap.UpdateAddStringValue(constlabels.SrcWorkloadKind, podInfo.WorkloadKind)
+	labelMap.UpdateAddStringValue(constlabels.SrcWorkloadName, podInfo.WorkloadName)
+	labelMap.UpdateAddStringValue(constlabels.SrcPod, podInfo.PodName)
+	labelMap.UpdateAddStringValue(constlabels.SrcIp, podInfo.Ip)
 	if podInfo.ServiceInfo != nil {
-		labelMap.AddStringValue(constlabels.SrcService, podInfo.ServiceInfo.ServiceName)
+		labelMap.UpdateAddStringValue(constlabels.SrcService, podInfo.ServiceInfo.ServiceName)
 	}
 }
 
 func addContainerMetaInfoLabelDST(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {
-	labelMap.AddStringValue(constlabels.DstContainer, containerInfo.Name)
+	labelMap.UpdateAddStringValue(constlabels.DstContainer, containerInfo.Name)
 	addPodMetaInfoLabelDST(labelMap, containerInfo.RefPodInfo)
 }
 
 func addPodMetaInfoLabelDST(labelMap *model.AttributeMap, podInfo *kubernetes.K8sPodInfo) {
-	labelMap.AddStringValue(constlabels.DstNode, podInfo.NodeName)
-	labelMap.AddStringValue(constlabels.DstNodeIp, podInfo.NodeAddress)
-	labelMap.AddStringValue(constlabels.DstNamespace, podInfo.Namespace)
-	labelMap.AddStringValue(constlabels.DstWorkloadKind, podInfo.WorkloadKind)
-	labelMap.AddStringValue(constlabels.DstWorkloadName, podInfo.WorkloadName)
-	labelMap.AddStringValue(constlabels.DstPod, podInfo.PodName)
+	labelMap.UpdateAddStringValue(constlabels.DstNode, podInfo.NodeName)
+	labelMap.UpdateAddStringValue(constlabels.DstNodeIp, podInfo.NodeAddress)
+	labelMap.UpdateAddStringValue(constlabels.DstNamespace, podInfo.Namespace)
+	labelMap.UpdateAddStringValue(constlabels.DstWorkloadKind, podInfo.WorkloadKind)
+	labelMap.UpdateAddStringValue(constlabels.DstWorkloadName, podInfo.WorkloadName)
+	labelMap.UpdateAddStringValue(constlabels.DstPod, podInfo.PodName)
 	if labelMap.GetStringValue(constlabels.DstIp) == "" {
-		labelMap.AddStringValue(constlabels.DstIp, podInfo.Ip)
+		labelMap.UpdateAddStringValue(constlabels.DstIp, podInfo.Ip)
 	}
 }

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
@@ -15,7 +15,7 @@ const (
 
 type gauges struct {
 	*model.GaugeGroup
-	targetValues []model.Gauge
+	targetValues []*model.Gauge
 	targetLabels *model.AttributeMap
 }
 
@@ -30,7 +30,7 @@ func newGauges(g *model.GaugeGroup) *gauges {
 
 	return &gauges{
 		GaugeGroup:   gaugeGroupCp,
-		targetValues: make([]model.Gauge, 0, len(g.Values)),
+		targetValues: make([]*model.Gauge, 0, len(g.Values)),
 		targetLabels: model.NewAttributeMap(),
 	}
 }
@@ -60,7 +60,7 @@ func (g gauges) Process(cfg *Config, relabels ...Relabel) *model.GaugeGroup {
 func MetricName(cfg *Config, g *gauges) {
 	for _, gauge := range g.Values {
 		if name := constlabels.ToKindlingMetricName(gauge.Name, g.Labels.GetBoolValue(constlabels.IsServer)); name != "" {
-			g.targetValues = append(g.targetValues, model.Gauge{
+			g.targetValues = append(g.targetValues, &model.Gauge{
 				Name:  name,
 				Value: gauge.Value,
 			})
@@ -78,7 +78,7 @@ func TraceName(cfg *Config, g *gauges) {
 		}
 	}
 
-	g.targetValues = append(g.targetValues, model.Gauge{
+	g.targetValues = append(g.targetValues, &model.Gauge{
 		Name:  constlabels.ToKindlingTraceAsMetricName(),
 		Value: requestDuration,
 	})
@@ -86,7 +86,7 @@ func TraceName(cfg *Config, g *gauges) {
 
 func ProtocolDetailMetricName(cfg *Config, g *gauges) {
 	for _, gauge := range g.Values {
-		g.targetValues = append(g.targetValues, model.Gauge{
+		g.targetValues = append(g.targetValues, &model.Gauge{
 			Name:  constlabels.ToKindlingDetailMetricName(gauge.Name, g.Labels.GetStringValue(constlabels.Protocol)),
 			Value: gauge.Value,
 		})

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary_test.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary_test.go
@@ -34,7 +34,7 @@ func Test_gauges_Process(t *testing.T) {
 			name: "Trace",
 			args: args{
 				gauges:   newGauges(newInnerGauges(true)),
-				cfg:      &Config{NeedTraceAsMetric: true},
+				cfg:      &Config{NeedTraceAsMetric: true, NeedPodDetail: true},
 				relabels: []Relabel{TraceName, TopologyInstanceInfo, TopologyK8sInfo, ServiceProtocolInfo, TraceStatusInfo},
 			},
 			want: getTrace(),
@@ -43,7 +43,7 @@ func Test_gauges_Process(t *testing.T) {
 			name: "ServiceMetric",
 			args: args{
 				gauges:   newGauges(newInnerGauges(true)),
-				cfg:      &Config{NeedTraceAsMetric: true},
+				cfg:      &Config{NeedTraceAsMetric: true, NeedPodDetail: true},
 				relabels: []Relabel{MetricName, ServiceInstanceInfo, ServiceK8sInfo, ServiceProtocolInfo},
 			},
 			want: getServiceMetric(),
@@ -52,7 +52,7 @@ func Test_gauges_Process(t *testing.T) {
 			name: "TopologyMetric",
 			args: args{
 				gauges:   newGauges(newInnerGauges(false)),
-				cfg:      &Config{NeedTraceAsMetric: true},
+				cfg:      &Config{NeedTraceAsMetric: true, NeedPodDetail: true},
 				relabels: []Relabel{MetricName, TopologyInstanceInfo, TopologyK8sInfo, SrcDockerInfo, TopologyProtocolInfo},
 			},
 			want: getTopologyMetric(),
@@ -92,7 +92,7 @@ func Test_gauges_Process(t *testing.T) {
 func newInnerGauges(isServer bool) *model.GaugeGroup {
 	gaugesGroup := model.GaugeGroup{
 		Name: "testGauge",
-		Values: []model.Gauge{
+		Values: []*model.Gauge{
 			{constvalues.RequestIo, values[constvalues.RequestIo]},
 			{constvalues.ResponseIo, values[constvalues.ResponseIo]},
 			{constvalues.RequestTotalTime, values[constvalues.RequestTotalTime]},
@@ -144,7 +144,7 @@ func newInnerGauges(isServer bool) *model.GaugeGroup {
 func getTrace() *model.GaugeGroup {
 	gaugesGroup := model.GaugeGroup{
 		Name: "testGauge",
-		Values: []model.Gauge{
+		Values: []*model.Gauge{
 			{"kindling_trace_request_duration_nanoseconds", values[constvalues.RequestTotalTime]},
 		},
 		Labels:    model.NewAttributeMap(),
@@ -185,7 +185,7 @@ func getTrace() *model.GaugeGroup {
 func getServiceMetric() *model.GaugeGroup {
 	gaugesGroup := model.GaugeGroup{
 		Name: "testGauge",
-		Values: []model.Gauge{
+		Values: []*model.Gauge{
 			{"kindling_entity_request_receive_bytes_total", values[constvalues.RequestIo]},
 			{"kindling_entity_request_send_bytes_total", values[constvalues.ResponseIo]},
 			{"kindling_entity_request_duration_nanoseconds", values[constvalues.RequestTotalTime]},
@@ -219,7 +219,7 @@ func getServiceMetric() *model.GaugeGroup {
 func getTopologyMetric() *model.GaugeGroup {
 	gaugesGroup := model.GaugeGroup{
 		Name: "testGauge",
-		Values: []model.Gauge{
+		Values: []*model.Gauge{
 			{"kindling_topology_request_request_bytes_total", values[constvalues.RequestIo]},
 			{"kindling_topology_request_response_bytes_total", values[constvalues.ResponseIo]},
 			{"kindling_topology_request_duration_nanoseconds", values[constvalues.RequestTotalTime]},

--- a/collector/consumer/processor/nodemetricprocessor/node_metric_processor.go
+++ b/collector/consumer/processor/nodemetricprocessor/node_metric_processor.go
@@ -66,7 +66,7 @@ func (p *NodeMetricProcessor) process(gaugeGroup *model.GaugeGroup, role string)
 
 	var retError error
 	// For request, the transmit direction is SrcNode->DstNode
-	requestIo, ok := gaugeGroup.GetValue(constvalues.RequestIo)
+	requestIo, ok := gaugeGroup.GetGauge(constvalues.RequestIo)
 	if ok {
 		newLabels := model.NewAttributeMapWithValues(map[string]model.AttributeValue{
 			constlabels.SrcNodeIp: model.NewStringValue(srcNodeIp),
@@ -91,7 +91,7 @@ func (p *NodeMetricProcessor) process(gaugeGroup *model.GaugeGroup, role string)
 		}
 	}
 	// For response, the transmit direction is DstNode->SrcNode
-	responseIo, ok := gaugeGroup.GetValue(constvalues.ResponseIo)
+	responseIo, ok := gaugeGroup.GetGauge(constvalues.ResponseIo)
 	if ok {
 		newLabels := model.NewAttributeMapWithValues(map[string]model.AttributeValue{
 			constlabels.SrcNodeIp: model.NewStringValue(dstNodeIp),

--- a/collector/consumer/processor/nodemetricprocessor/node_metric_processor.go
+++ b/collector/consumer/processor/nodemetricprocessor/node_metric_processor.go
@@ -75,7 +75,7 @@ func (p *NodeMetricProcessor) process(gaugeGroup *model.GaugeGroup, role string)
 			constlabels.DstNode:   model.NewStringValue(dstNodeName),
 			"role":                model.NewStringValue(role),
 		})
-		newValue := model.Gauge{
+		newValue := &model.Gauge{
 			Name:  "kindling_node_transmit_bytes_total",
 			Value: requestIo.Value,
 		}
@@ -100,7 +100,7 @@ func (p *NodeMetricProcessor) process(gaugeGroup *model.GaugeGroup, role string)
 			constlabels.DstNode:   model.NewStringValue(srcNodeName),
 			"role":                model.NewStringValue(role),
 		})
-		newValue := model.Gauge{
+		newValue := &model.Gauge{
 			Name:  "kindling_node_transmit_bytes_total",
 			Value: responseIo.Value,
 		}

--- a/collector/model/attribute_map.go
+++ b/collector/model/attribute_map.go
@@ -19,15 +19,15 @@ func NewAttributeMapWithValues(values map[string]AttributeValue) *AttributeMap {
 }
 
 func NewStringValue(value string) AttributeValue {
-	return stringValue{value: value}
+	return &stringValue{value: value}
 }
 
 func NewIntValue(value int64) AttributeValue {
-	return intValue{value: value}
+	return &intValue{value: value}
 }
 
 func NewBoolValue(value bool) AttributeValue {
-	return boolValue{value: value}
+	return &boolValue{value: value}
 }
 
 func (attributes *AttributeMap) Merge(other *AttributeMap) {
@@ -54,43 +54,67 @@ func (attributes *AttributeMap) HasAttribute(key string) bool {
 
 func (attributes *AttributeMap) GetStringValue(key string) string {
 	value := attributes.values[key]
-	if x, ok := value.(stringValue); ok {
+	if x, ok := value.(*stringValue); ok {
 		return x.value
 	}
 	return ""
 }
 
 func (attributes *AttributeMap) AddStringValue(key string, value string) {
-	attributes.values[key] = stringValue{
+	attributes.values[key] = &stringValue{
 		value: value,
+	}
+}
+
+func (attributes *AttributeMap) UpdateAddStringValue(key string, value string) {
+	if v, ok := attributes.values[key]; ok {
+		v.(*stringValue).value = value
+	} else {
+		attributes.AddStringValue(key, value)
 	}
 }
 
 func (attributes *AttributeMap) GetIntValue(key string) int64 {
 	value := attributes.values[key]
-	if x, ok := value.(intValue); ok {
+	if x, ok := value.(*intValue); ok {
 		return x.value
 	}
 	return 0
 }
 
 func (attributes *AttributeMap) AddIntValue(key string, value int64) {
-	attributes.values[key] = intValue{
+	attributes.values[key] = &intValue{
 		value: value,
+	}
+}
+
+func (attributes *AttributeMap) UpdateAddIntValue(key string, value int64) {
+	if v, ok := attributes.values[key]; ok {
+		v.(*intValue).value = value
+	} else {
+		attributes.AddIntValue(key, value)
 	}
 }
 
 func (attributes *AttributeMap) GetBoolValue(key string) bool {
 	value := attributes.values[key]
-	if x, ok := value.(boolValue); ok {
+	if x, ok := value.(*boolValue); ok {
 		return x.value
 	}
 	return false
 }
 
 func (attributes *AttributeMap) AddBoolValue(key string, value bool) {
-	attributes.values[key] = boolValue{
+	attributes.values[key] = &boolValue{
 		value: value,
+	}
+}
+
+func (attributes *AttributeMap) UpdateAddBoolValue(key string, value bool) {
+	if v, ok := attributes.values[key]; ok {
+		v.(*boolValue).value = value
+	} else {
+		attributes.AddBoolValue(key, value)
 	}
 }
 
@@ -130,7 +154,7 @@ type stringValue struct {
 	value string
 }
 
-func (v stringValue) ToString() string {
+func (v *stringValue) ToString() string {
 	return v.value
 }
 
@@ -138,7 +162,7 @@ type intValue struct {
 	value int64
 }
 
-func (v intValue) ToString() string {
+func (v *intValue) ToString() string {
 	return strconv.FormatInt(v.value, 10)
 }
 
@@ -146,6 +170,6 @@ type boolValue struct {
 	value bool
 }
 
-func (v boolValue) ToString() string {
+func (v *boolValue) ToString() string {
 	return strconv.FormatBool(v.value)
 }

--- a/collector/model/attribute_map.go
+++ b/collector/model/attribute_map.go
@@ -141,6 +141,13 @@ func (attributes *AttributeMap) GetValues() map[string]AttributeValue {
 	return nil
 }
 
+// ResetValues sets the default value for all elements. Used for implementing sync.Pool.
+func (attributes *AttributeMap) ResetValues() {
+	for _, v := range attributes.values {
+		v.Reset()
+	}
+}
+
 func (attributes *AttributeMap) String() string {
 	json, _ := json.Marshal(attributes.ToStringMap())
 	return string(json)
@@ -148,6 +155,7 @@ func (attributes *AttributeMap) String() string {
 
 type AttributeValue interface {
 	ToString() string
+	Reset()
 }
 
 type stringValue struct {
@@ -158,6 +166,10 @@ func (v *stringValue) ToString() string {
 	return v.value
 }
 
+func (v *stringValue) Reset() {
+	v.value = ""
+}
+
 type intValue struct {
 	value int64
 }
@@ -166,10 +178,18 @@ func (v *intValue) ToString() string {
 	return strconv.FormatInt(v.value, 10)
 }
 
+func (v *intValue) Reset() {
+	v.value = 0
+}
+
 type boolValue struct {
 	value bool
 }
 
 func (v *boolValue) ToString() string {
 	return strconv.FormatBool(v.value)
+}
+
+func (v *boolValue) Reset() {
+	v.value = false
 }

--- a/collector/model/metric.go
+++ b/collector/model/metric.go
@@ -28,13 +28,33 @@ func NewGaugeGroup(name string, labels *AttributeMap, timestamp uint64, values .
 	}
 }
 
-func (g *GaugeGroup) GetValue(name string) (*Gauge, bool) {
+func (g *GaugeGroup) GetGauge(name string) (*Gauge, bool) {
 	for _, gauge := range g.Values {
 		if gauge.Name == name {
 			return gauge, true
 		}
 	}
 	return &Gauge{}, false
+}
+
+func (g *GaugeGroup) AddGaugeWithName(name string, value int64) {
+	g.AddGauge(&Gauge{Name: name, Value: value})
+}
+
+func (g *GaugeGroup) AddGauge(gauge *Gauge) {
+	if g.Values == nil {
+		g.Values = make([]*Gauge, 0)
+	}
+	g.Values = append(g.Values, gauge)
+}
+
+// UpdateAddGauge updates the gauge with the key of 'name' if existing, or adds the gauge if not existing.
+func (g *GaugeGroup) UpdateAddGauge(name string, value int64) {
+	if gauge, ok := g.GetGauge(name); ok {
+		gauge.Value = value
+	} else {
+		g.AddGaugeWithName(name, value)
+	}
 }
 
 func (g *GaugeGroup) String() string {

--- a/collector/model/metric.go
+++ b/collector/model/metric.go
@@ -9,7 +9,7 @@ import (
 // Notice: Currently the definition of GaugeGroup is not stable.
 type GaugeGroup struct {
 	Name      string
-	Values    []Gauge
+	Values    []*Gauge
 	Labels    *AttributeMap
 	Timestamp uint64
 }
@@ -19,7 +19,7 @@ type Gauge struct {
 	Value int64
 }
 
-func NewGaugeGroup(name string, labels *AttributeMap, timestamp uint64, values ...Gauge) *GaugeGroup {
+func NewGaugeGroup(name string, labels *AttributeMap, timestamp uint64, values ...*Gauge) *GaugeGroup {
 	return &GaugeGroup{
 		Name:      name,
 		Values:    values,
@@ -28,13 +28,13 @@ func NewGaugeGroup(name string, labels *AttributeMap, timestamp uint64, values .
 	}
 }
 
-func (g *GaugeGroup) GetValue(name string) (Gauge, bool) {
+func (g *GaugeGroup) GetValue(name string) (*Gauge, bool) {
 	for _, gauge := range g.Values {
 		if gauge.Name == name {
 			return gauge, true
 		}
 	}
-	return Gauge{}, false
+	return &Gauge{}, false
 }
 
 func (g *GaugeGroup) String() string {
@@ -45,4 +45,13 @@ func (g *GaugeGroup) String() string {
 	str.WriteString(fmt.Sprintf("\tLabels: %v\n", g.Labels))
 	str.WriteString(fmt.Sprintf("\tTimestamp: %d\n", g.Timestamp))
 	return str.String()
+}
+
+func (g *GaugeGroup) Reset() {
+	g.Name = ""
+	for _, v := range g.Values {
+		v.Value = 0
+	}
+	g.Labels.ResetValues()
+	g.Timestamp = 0
 }


### PR DESCRIPTION
Related to issue #63 

The `GaugeGroup` object is put back to the pool once it passes through the processing chain. Note we reuse the objects created before when the `NetworkAnalyzer` generates a new request, and all the labels added before are still there, so there may be some unuseful labels that have to be discarded by later processors.

We also add an `Update` method to `attributeMap` to make the labels reusable.