### PR TITLE
Add variable GOGC=400 to the deployment yaml

### DIFF
--- a/deploy/kindling-deploy.yml
+++ b/deploy/kindling-deploy.yml
@@ -107,6 +107,8 @@ spec:
           requests:
             memory: 300Mi
         env:
+        - name: GOGC
+          value: "400"
         - name: MY_NODE_IP
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Related to issue #63.
Like what we found https://github.com/Kindling-project/kindling/issues/63#issuecomment-1056647203, we could set GOGC  400 to reduce the frequency of GC.
