### PR TITLE
Add metadata of container to the output data

### DIFF
--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -257,6 +257,7 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 
 func addContainerMetaInfoLabelSRC(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {
 	labelMap.UpdateAddStringValue(constlabels.SrcContainer, containerInfo.Name)
+	labelMap.UpdateAddStringValue(constlabels.SrcContainerId, containerInfo.ContainerId)
 	addPodMetaInfoLabelSRC(labelMap, containerInfo.RefPodInfo)
 }
 
@@ -275,6 +276,7 @@ func addPodMetaInfoLabelSRC(labelMap *model.AttributeMap, podInfo *kubernetes.K8
 
 func addContainerMetaInfoLabelDST(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {
 	labelMap.UpdateAddStringValue(constlabels.DstContainer, containerInfo.Name)
+	labelMap.UpdateAddStringValue(constlabels.DstContainerId, containerInfo.ContainerId)
 	addPodMetaInfoLabelDST(labelMap, containerInfo.RefPodInfo)
 }
 

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
@@ -147,10 +147,19 @@ func TopologyK8sInfo(cfg *Config, g *gauges) {
 	}
 }
 
-func SrcDockerInfo(cfg *Config, g *gauges) {
+// SrcContainerInfo adds container level information to the input gauges if cfg.NeedPodDetail is enabled.
+func SrcContainerInfo(cfg *Config, g *gauges) {
 	if cfg.NeedPodDetail {
 		g.targetLabels.AddStringValue(constlabels.SrcContainer, g.Labels.GetStringValue(constlabels.SrcContainer))
 		g.targetLabels.AddStringValue(constlabels.SrcContainerId, g.Labels.GetStringValue(constlabels.SrcContainerId))
+	}
+}
+
+// DstContainerInfo adds container level information to the input gauges if cfg.NeedPodDetail is enabled.
+func DstContainerInfo(cfg *Config, g *gauges) {
+	if cfg.NeedPodDetail {
+		g.targetLabels.AddStringValue(constlabels.DstContainer, g.Labels.GetStringValue(constlabels.DstContainer))
+		g.targetLabels.AddStringValue(constlabels.DstContainerId, g.Labels.GetStringValue(constlabels.DstContainerId))
 	}
 }
 

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary_test.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary_test.go
@@ -53,7 +53,7 @@ func Test_gauges_Process(t *testing.T) {
 			args: args{
 				gauges:   newGauges(newInnerGauges(false)),
 				cfg:      &Config{NeedTraceAsMetric: true, NeedPodDetail: true},
-				relabels: []Relabel{MetricName, TopologyInstanceInfo, TopologyK8sInfo, SrcDockerInfo, TopologyProtocolInfo},
+				relabels: []Relabel{MetricName, TopologyInstanceInfo, TopologyK8sInfo, SrcContainerInfo, TopologyProtocolInfo},
 			},
 			want: getTopologyMetric(),
 		},

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
@@ -41,7 +41,8 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 	if r.cfg.NeedTraceAsResourceSpan && common.isSlowOrError() {
 		// Trace As Span
 		span := newGauges(gaugeGroup)
-		spanErr = r.nextConsumer.Consume(span.Process(r.cfg, SpanName, TopologyTraceInstanceInfo, TopologyTraceK8sInfo, SpanProtocolInfo, TraceValuesToLabel))
+		spanErr = r.nextConsumer.Consume(span.Process(r.cfg, SpanName, TopologyTraceInstanceInfo,
+			TopologyTraceK8sInfo, SrcContainerInfo, DstContainerInfo, SpanProtocolInfo, TraceValuesToLabel))
 	}
 
 	// The data when the field is Error is true and the error Type is 2, do not generate metric

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
@@ -35,7 +35,8 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 	if r.cfg.NeedTraceAsMetric && common.isSlowOrError() {
 		// Trace as Metric
 		trace := newGauges(gaugeGroup)
-		traceErr = r.nextConsumer.Consume(trace.Process(r.cfg, TraceName, TopologyTraceInstanceInfo, TopologyTraceK8sInfo, ServiceProtocolInfo, TraceStatusInfo))
+		traceErr = r.nextConsumer.Consume(trace.Process(r.cfg, TraceName, TopologyTraceInstanceInfo,
+			TopologyTraceK8sInfo, ServiceProtocolInfo, TraceStatusInfo))
 	}
 	if r.cfg.NeedTraceAsResourceSpan && common.isSlowOrError() {
 		// Trace As Span
@@ -62,14 +63,16 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 				externalGaugeGroup := newGauges(gaugeGroup)
 				// Here we have to modify the field "IsServer" to generate the metric.
 				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, false)
-				metricErr2 = r.nextConsumer.Consume(externalGaugeGroup.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo, TopologyProtocolInfo))
+				metricErr2 = r.nextConsumer.Consume(externalGaugeGroup.Process(r.cfg, MetricName, TopologyInstanceInfo,
+					TopologyK8sInfo, DstContainerInfo, TopologyProtocolInfo))
 				// In case of using the original data later, we reset the field "IsServer".
 				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, true)
 			}
 		}
 		return multierr.Combine(traceErr, spanErr, metricErr, metricErr2)
 	} else {
-		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo, SrcDockerInfo, TopologyProtocolInfo))
-		return multierr.Combine(traceErr, spanErr, metricErr)
+		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo,
+			SrcContainerInfo, DstContainerInfo, TopologyProtocolInfo))
+		return multierr.Combine(traceErr, metricErr)
 	}
 }

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor.go
@@ -36,7 +36,7 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 		// Trace as Metric
 		trace := newGauges(gaugeGroup)
 		traceErr = r.nextConsumer.Consume(trace.Process(r.cfg, TraceName, TopologyTraceInstanceInfo,
-			TopologyTraceK8sInfo, ServiceProtocolInfo, TraceStatusInfo))
+			TopologyTraceK8sInfo, SrcContainerInfo, DstContainerInfo, ServiceProtocolInfo, TraceStatusInfo))
 	}
 	if r.cfg.NeedTraceAsResourceSpan && common.isSlowOrError() {
 		// Trace As Span

--- a/collector/consumer/processor/kindlingformatprocessor/relabel_processor_test.go
+++ b/collector/consumer/processor/kindlingformatprocessor/relabel_processor_test.go
@@ -64,28 +64,28 @@ func makeGaugeGroup(latency int64) *model.GaugeGroup {
 		constlabels.IsSlow:          model.NewBoolValue(true),
 	})
 
-	latencyGauge := model.Gauge{
+	latencyGauge := &model.Gauge{
 		Name:  "kindling_entity_request_duration_nanoseconds",
 		Value: latency,
 	}
 
-	requestTimeGauge := model.Gauge{
+	requestTimeGauge := &model.Gauge{
 		Name:  constvalues.RequestSentTime,
 		Value: 300,
 	}
-	waitTtfbTime := model.Gauge{
+	waitTtfbTime := &model.Gauge{
 		Name:  constvalues.WaitingTtfbTime,
 		Value: 400,
 	}
-	contentDownload := model.Gauge{
+	contentDownload := &model.Gauge{
 		Name:  constvalues.ContentDownloadTime,
 		Value: 500,
 	}
-	connectTime := model.Gauge{
+	connectTime := &model.Gauge{
 		Name:  constvalues.ConnectTime,
 		Value: 600,
 	}
-	reqio := model.Gauge{
+	reqio := &model.Gauge{
 		Name:  constvalues.RequestIo,
 		Value: 700,
 	}


### PR DESCRIPTION
Since we can get the container metadata, the output metrics and traces could also include it. It is useful when the users want to know which container receives or sends the requests.

The cardinality of metric doesn't increase much because a combination of `Port` and `PodName` already included before actually stands for exact one container/container's id.