### PR TITLE
Rename protocol "generic" to "NOSUPPORT" to make it more comprehensible

### DIFF
--- a/collector/analyzer/network/network_analyzer.go
+++ b/collector/analyzer/network/network_analyzer.go
@@ -319,7 +319,7 @@ func (na *NetworkAnalyzer) parseProtocols(mps *messagePairs) []*model.GaugeGroup
 		for _, parser := range cacheParsers {
 			records := na.parseProtocol(mps, parser)
 			if records != nil {
-				if protocol.UNSUPPORTED == parser.GetProtocol() {
+				if protocol.NOSUPPORT == parser.GetProtocol() {
 					// Reset mapping for  generic and port when exceed threshold so as to parsed by other protcols.
 					if parser.AddPortCount(port) == CACHE_RESET_THRESHOLD {
 						parser.ResetPort(port)
@@ -342,7 +342,7 @@ func (na *NetworkAnalyzer) parseProtocols(mps *messagePairs) []*model.GaugeGroup
 			return records
 		}
 	}
-	return na.getRecords(mps, protocol.UNSUPPORTED, nil)
+	return na.getRecords(mps, protocol.NOSUPPORT, nil)
 }
 
 func (na *NetworkAnalyzer) parseProtocol(mps *messagePairs, parser *protocol.ProtocolParser) []*model.GaugeGroup {

--- a/collector/analyzer/network/network_analyzer.go
+++ b/collector/analyzer/network/network_analyzer.go
@@ -292,7 +292,7 @@ func (na *NetworkAnalyzer) parseProtocols(mps *messagePairs) []*model.GaugeGroup
 	if found {
 		if mps.requests == nil {
 			// Connect Timeout
-			return na.getConnectFailRecords(mps, staticProtocol)
+			return na.getConnectFailRecords(mps)
 		}
 
 		if parser, exist := na.protocolMap[staticProtocol]; exist {
@@ -309,7 +309,7 @@ func (na *NetworkAnalyzer) parseProtocols(mps *messagePairs) []*model.GaugeGroup
 
 	if mps.requests == nil {
 		// Connect Timeout
-		return na.getConnectFailRecords(mps, protocol.GENERIC)
+		return na.getConnectFailRecords(mps)
 	}
 
 	// Step2 Cache protocol and port
@@ -319,7 +319,7 @@ func (na *NetworkAnalyzer) parseProtocols(mps *messagePairs) []*model.GaugeGroup
 		for _, parser := range cacheParsers {
 			records := na.parseProtocol(mps, parser)
 			if records != nil {
-				if protocol.GENERIC == parser.GetProtocol() {
+				if protocol.UNSUPPORTED == parser.GetProtocol() {
 					// Reset mapping for  generic and port when exceed threshold so as to parsed by other protcols.
 					if parser.AddPortCount(port) == CACHE_RESET_THRESHOLD {
 						parser.ResetPort(port)
@@ -342,7 +342,7 @@ func (na *NetworkAnalyzer) parseProtocols(mps *messagePairs) []*model.GaugeGroup
 			return records
 		}
 	}
-	return na.getRecords(mps, protocol.GENERIC, nil)
+	return na.getRecords(mps, protocol.UNSUPPORTED, nil)
 }
 
 func (na *NetworkAnalyzer) parseProtocol(mps *messagePairs, parser *protocol.ProtocolParser) []*model.GaugeGroup {
@@ -431,7 +431,7 @@ func (na *NetworkAnalyzer) parseProtocol(mps *messagePairs, parser *protocol.Pro
 	return na.getRecords(mps, parser.GetProtocol(), responseMsg.GetAttributes())
 }
 
-func (na *NetworkAnalyzer) getConnectFailRecords(mps *messagePairs, protocol string) []*model.GaugeGroup {
+func (na *NetworkAnalyzer) getConnectFailRecords(mps *messagePairs) []*model.GaugeGroup {
 	evt := mps.connects.event
 	ret := na.gaugeGroupPool.Get()
 	ret.UpdateAddGauge(constvalues.ConnectTime, int64(mps.connects.getDuration()))

--- a/collector/analyzer/network/protocol/generic/generic_parser.go
+++ b/collector/analyzer/network/protocol/generic/generic_parser.go
@@ -8,7 +8,7 @@ func NewGenericParser() *protocol.ProtocolParser {
 	requestParser := protocol.CreatePkgParser(fastfailGeneric(), parseGeneric())
 	responseParser := protocol.CreatePkgParser(fastfailGeneric(), parseGeneric())
 
-	return protocol.NewProtocolParser(protocol.UNSUPPORTED, requestParser, responseParser, nil)
+	return protocol.NewProtocolParser(protocol.NOSUPPORT, requestParser, responseParser, nil)
 }
 
 func fastfailGeneric() protocol.FastFailFn {

--- a/collector/analyzer/network/protocol/generic/generic_parser.go
+++ b/collector/analyzer/network/protocol/generic/generic_parser.go
@@ -8,7 +8,7 @@ func NewGenericParser() *protocol.ProtocolParser {
 	requestParser := protocol.CreatePkgParser(fastfailGeneric(), parseGeneric())
 	responseParser := protocol.CreatePkgParser(fastfailGeneric(), parseGeneric())
 
-	return protocol.NewProtocolParser(protocol.GENERIC, requestParser, responseParser, nil)
+	return protocol.NewProtocolParser(protocol.UNSUPPORTED, requestParser, responseParser, nil)
 }
 
 func fastfailGeneric() protocol.FastFailFn {

--- a/collector/analyzer/network/protocol/protocol.go
+++ b/collector/analyzer/network/protocol/protocol.go
@@ -1,10 +1,10 @@
 package protocol
 
 const (
-	HTTP        = "http"
-	DNS         = "dns"
-	KAFKA       = "kafka"
-	MYSQL       = "mysql"
-	REDIS       = "redis"
-	UNSUPPORTED = "UNSUPPORTED"
+	HTTP      = "http"
+	DNS       = "dns"
+	KAFKA     = "kafka"
+	MYSQL     = "mysql"
+	REDIS     = "redis"
+	NOSUPPORT = "NOSUPPORT"
 )

--- a/collector/analyzer/network/protocol/protocol.go
+++ b/collector/analyzer/network/protocol/protocol.go
@@ -1,10 +1,10 @@
 package protocol
 
 const (
-	HTTP    = "http"
-	DNS     = "dns"
-	KAFKA   = "kafka"
-	MYSQL   = "mysql"
-	REDIS   = "redis"
-	GENERIC = "generic"
+	HTTP        = "http"
+	DNS         = "dns"
+	KAFKA       = "kafka"
+	MYSQL       = "mysql"
+	REDIS       = "redis"
+	UNSUPPORTED = "UNSUPPORTED"
 )

--- a/collector/consumer/processor/kindlingformatprocessor/protocol.go
+++ b/collector/consumer/processor/kindlingformatprocessor/protocol.go
@@ -8,14 +8,13 @@ import (
 type ProtocolType string
 
 const (
-	generic = "generic"
-	http    = "http"
-	http2   = "http2"
-	grpc    = "grpc"
-	dubbo   = "dubbo"
-	dns     = "dns"
-	kafka   = "kafka"
-	mysql   = "mysql"
+	http  = "http"
+	http2 = "http2"
+	grpc  = "grpc"
+	dubbo = "dubbo"
+	dns   = "dns"
+	kafka = "kafka"
+	mysql = "mysql"
 )
 
 func fillSpecialProtocolLabels(g *gauges, protocol ProtocolType) {


### PR DESCRIPTION
Rename protocol name “generic” to “UNSUPPORTED” to make it more comprehensible. Note the metric with this protocol is not accurate.