### PR TITLE
Change spanTrace name to "KSpanInfo"

### DIFF
--- a/collector/model/constvalues/const.go
+++ b/collector/model/constvalues/const.go
@@ -10,5 +10,5 @@ const (
 	RequestIo  = "request_io"
 	ResponseIo = "response_io"
 
-	SpanInfo = "span_info"
+	SpanInfo = "KSpanInfo"
 )


### PR DESCRIPTION
The name must be "KSpanInfo" to make it queryable on Aliyun.