### PR TITLE
Improve conntracker to avoid the workers exiting

### DIFF
--- a/collector/metadata/conntracker/conntracker.go
+++ b/collector/metadata/conntracker/conntracker.go
@@ -70,9 +70,11 @@ func newConntrackerOnce(maxStateSize int, workerNumber uint8) (*Conntracker, err
 		if err = c.SetOption(netlink.ListenAllNSID, true); err != nil {
 			log.Printf("Warn: error setting up Netlink option ListenAllNSID: %s", err)
 		}
-		// if err = c.SetOption(netlink.NoENOBUFS, true); err != nil {
-		// 	log.Printf("Warn: error setting up Netlink option NoENOBUFS: %s", err)
-		// }
+		// Enabling this option will avoid receiving ENOBUFS errors and prevent the workers from
+		// exiting, but remember that the flows will still be dropped if no buffer is available.
+		if err = c.SetOption(netlink.NoENOBUFS, true); err != nil {
+			log.Printf("Warn: error setting up Netlink option NoENOBUFS: %s", err)
+		}
 		// This will modify the net.core.rmem_default config, which is about 200KB by default, to
 		// receive conntrack flows as many as possible before complaining about "no buffer" error.
 		if err = c.SetReadBuffer(netlinkBufferSize); err != nil {

--- a/collector/metadata/conntracker/conntracker.go
+++ b/collector/metadata/conntracker/conntracker.go
@@ -113,12 +113,8 @@ func (ctr *Conntracker) poll(workerNumber uint8) (err error) {
 		log.Fatal(err)
 	}
 	go func() {
-		ticker := time.NewTicker(1 * time.Second)
 		for {
 			select {
-			case <-ticker.C:
-				log.Printf("Conntrack statistics: %v", ctr.cache.stats)
-				log.Printf("Current cache size: %d", ctr.cache.Len())
 			case err := <-errCh:
 				log.Printf("error occured during receiving message from conntracker socket: %s", err)
 			}


### PR DESCRIPTION
As I said in #87, this PR makes two changes:
- Increase the receive buffer size of Netlink which is about 200KB by default. 1MB is appropriate for this case. But this won't avoid the problem happening as there will always be more loads.
- Enable the option of `NETLINK_NO_ENOBUFS` provided by Netlink. As said in the [documentation](https://man7.org/linux/man-pages/man7/netlink.7.html), it will avoid receiving `ENOBUFS` errors in which case the workers will always run without exiting. However, the error is still there and once it occurs, the conntrack flows not received by user will be dropped.

Based on these changes, the workers don't be terminated anymore when there are 5k+ conntrack flows updating per second. But it costs much more CPU time than before. The performance tune of the conntracker module is needed later.

This will close #87.