### PR TITLE
Update Installation.md

### DIFF
--- a/installation/Installation.md
+++ b/installation/Installation.md
@@ -56,7 +56,7 @@ cd kindling/probe
 Following steps are used to compile local kernel modules and eBPF modules, which you can skip if using precompiled modules by Kindling.
 
 ```bash
-git clone https://github.com/Kindling-project/agent-libs/commits/kindling-dev
+git clone -b kindling-dev https://github.com/Kindling-project/agent-libs
 cd agent-libs
 ```
 
@@ -70,12 +70,13 @@ sudo yum -y install kernel-devel-$(uname -r)
 # build and package eBPF, kernel probes
 docker run -it -v /usr:/host/usr -v /lib/modules:/host/lib/modules -v $PWD:/source kindlingproject/kernel-builder:latest
 tar -cvzf kindling-falcolib-probe.tar.gz kindling-falcolib-probe/
-# copy and wait for building the image
+# copy and wait for building the image.You may need to prefix the kindling path with your own absolute path
 cp kindling-falcolib-probe.tar.gz kindling/probe/deploy/
 ```
 
 
 ```bash
+cd ..
 # start compile container for binaries
 ./scripts/run_docker.sh
 # or start in daemon mode, choose one of them


### PR DESCRIPTION
1、change the command of cloning branch code
2、The copy operation usually reports an error because the previous absolute path is different
3、There is also a scripts folder below the agent-lib directory，we need go back to probe directory

Signed-off-by: yushu <906940958@qq.com>