### PR TITLE
Retain the direction of tcp metric as it is what we need

### DIFF
--- a/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
+++ b/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
@@ -86,6 +86,7 @@ func (a *TcpMetricAnalyzer) ConsumeEvent(event *model.KindlingEvent) error {
 }
 
 func (a *TcpMetricAnalyzer) generateRtt(event *model.KindlingEvent) (*model.GaugeGroup, error) {
+	// Only client-side has rtt metric
 	labels, err := a.getTupleLabels(event)
 	if err != nil {
 		return nil, err
@@ -143,45 +144,26 @@ func (a *TcpMetricAnalyzer) getTupleLabels(event *model.KindlingEvent) (*model.A
 	dIpString := model.IPLong2String(uint32(dIp.Value.GetUintValue()))
 	dPortUint := dPort.Value.GetUintValue()
 
-	dNatIp, dNatPort, role := a.findDNatTuple(sIpString, sPortUint, dIpString, dPortUint)
 	labels := model.NewAttributeMap()
-	switch role {
-	case "unknown":
-		labels.AddStringValue(constlabels.SrcIp, sIpString)
-		labels.AddIntValue(constlabels.SrcPort, int64(sPortUint))
-		labels.AddStringValue(constlabels.DstIp, dIpString)
-		labels.AddIntValue(constlabels.DstPort, int64(dPortUint))
-	case "client":
-		labels.AddStringValue(constlabels.SrcIp, sIpString)
-		labels.AddIntValue(constlabels.SrcPort, int64(sPortUint))
-		labels.AddStringValue(constlabels.DstIp, dNatIp)
-		labels.AddIntValue(constlabels.DstPort, dNatPort)
-	case "server":
-		labels.AddStringValue(constlabels.SrcIp, dIpString)
-		labels.AddIntValue(constlabels.SrcPort, int64(dPortUint))
-		labels.AddStringValue(constlabels.DstIp, sIpString)
-		labels.AddIntValue(constlabels.DstPort, int64(sPortUint))
-	}
+	labels.AddStringValue(constlabels.SrcIp, sIpString)
+	labels.AddIntValue(constlabels.SrcPort, int64(sPortUint))
+	labels.AddStringValue(constlabels.DstIp, dIpString)
+	labels.AddIntValue(constlabels.DstPort, int64(dPortUint))
 
+	dNatIp, dNatPort := a.findDNatTuple(sIpString, sPortUint, dIpString, dPortUint)
+	labels.AddStringValue(constlabels.DstIp, dNatIp)
+	labels.AddIntValue(constlabels.DstPort, dNatPort)
 	return labels, nil
 }
 
-func (a *TcpMetricAnalyzer) findDNatTuple(sIp string, sPort uint64, dIp string, dPort uint64) (string, int64, string) {
-	var role string
+func (a *TcpMetricAnalyzer) findDNatTuple(sIp string, sPort uint64, dIp string, dPort uint64) (string, int64) {
 	dNat := a.conntracker.GetDNATTupleWithString(sIp, dIp, uint16(sPort), uint16(dPort), 0)
 	if dNat == nil {
-		// Try again with reverse IP:Port
-		dNat = a.conntracker.GetDNATTupleWithString(dIp, sIp, uint16(dPort), uint16(sPort), 0)
-		role = "server"
-	} else {
-		role = "client"
-	}
-	if dNat == nil {
-		return "", -1, "unknown"
+		return "", -1
 	}
 	dNatIp := dNat.ReplSrcIP.String()
 	dNatPort := dNat.ReplSrcPort
-	return dNatIp, int64(dNatPort), role
+	return dNatIp, int64(dNatPort)
 }
 
 // Shutdown cleans all the resources used by the analyzer

--- a/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
+++ b/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
@@ -151,8 +151,8 @@ func (a *TcpMetricAnalyzer) getTupleLabels(event *model.KindlingEvent) (*model.A
 	labels.AddIntValue(constlabels.DstPort, int64(dPortUint))
 
 	dNatIp, dNatPort := a.findDNatTuple(sIpString, sPortUint, dIpString, dPortUint)
-	labels.AddStringValue(constlabels.DstIp, dNatIp)
-	labels.AddIntValue(constlabels.DstPort, dNatPort)
+	labels.AddStringValue(constlabels.DnatIp, dNatIp)
+	labels.AddIntValue(constlabels.DnatPort, dNatPort)
 	return labels, nil
 }
 

--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -249,9 +249,9 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 		return
 	}
 	if _, ok := p.metadata.GetNodeNameByIp(dstIp); ok {
-		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.DstNamespace, constlabels.InternalClusterNamespace)
 	} else {
-		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+		labelMap.UpdateAddStringValue(constlabels.DstNamespace, constlabels.ExternalClusterNamespace)
 	}
 }
 


### PR DESCRIPTION
Think of the request `A->B`, there are two TCP flows, which are A calls B and B returns to A, associated with it. We tried identifying the TCP flow direction to make it associated with the business request before, such as for the metric of retransmitting packet count, we want to change both the TCP flows of `A->B` and `B->A` to `A->B` so as to know whether the performance of a business request is affected by these two direction flows.

This is designed for simplifying the process of querying. But it turns out that we can not classify these directions accurately, so we decided to retain the real direction of the metric and leave the process of association to querying.