### PR TITLE
Replace metric type from UpDownCounter to GaugeObserver

### DIFF
--- a/collector/analyzer/network/metric.go
+++ b/collector/analyzer/network/metric.go
@@ -1,23 +1,33 @@
 package network
 
 import (
+	"context"
 	"sync"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
-
-var once sync.Once
-var netanalyzerMessagePairSize metric.Int64UpDownCounter
-var netanalyzerParsedRequestTotal metric.Int64Counter
 
 const (
 	netanalyzerMessagePairMetric   = "kindling_telemetry_netanalyer_messagepair_size"
 	netanalyzerParsedRequestMetric = "kindling_telemetry_netanalyer_parsedrequest_total"
 )
 
-func newSelfMetrics(meterProvider metric.MeterProvider) {
-	once.Do(func() {
-		netanalyzerMessagePairSize = metric.Must(meterProvider.Meter("kindling")).NewInt64UpDownCounter(netanalyzerMessagePairMetric)
+var (
+	selfTelemetryOnce                    sync.Once
+	netanalyzerMessagePairSizeInstrument metric.Int64GaugeObserver
+	netanalyzerParsedRequestTotal        metric.Int64Counter
+)
+
+func newSelfMetrics(meterProvider metric.MeterProvider, na *NetworkAnalyzer) {
+	selfTelemetryOnce.Do(func() {
+		netanalyzerMessagePairSizeInstrument = metric.Must(meterProvider.Meter("kindling")).NewInt64GaugeObserver(netanalyzerMessagePairMetric,
+			func(ctx context.Context, result metric.Int64ObserverResult) {
+				result.Observe(na.tcpMessagePairSize, attribute.String("type", "tcp"))
+				result.Observe(na.udpMessagePairSize, attribute.String("type", "udp"))
+			})
 		netanalyzerParsedRequestTotal = metric.Must(meterProvider.Meter("kindling")).NewInt64Counter(netanalyzerParsedRequestMetric)
+		// Suppress warnings of unused variables
+		_ = netanalyzerMessagePairSizeInstrument
 	})
 }


### PR DESCRIPTION
When the exporter is std, the value in UpDownCounter will be reset to zero. The metric value of message pair size got negative which is not expected.