### PR TITLE
optimize codes & filter out events

### DIFF
--- a/probe/src/probe/converter/converter.h
+++ b/probe/src/probe/converter/converter.h
@@ -7,7 +7,7 @@ class converter {
 public:
     converter();
     converter(uint64_t batch_size, uint64_t max_size);
-    ~converter();
+    virtual ~converter();
 	// source evt -> kindling evt
 	virtual void convert(void * evt);
     bool judge_batch_size();

--- a/probe/src/probe/publisher/publisher.cpp
+++ b/probe/src/probe/publisher/publisher.cpp
@@ -34,14 +34,9 @@ void publisher::consume_sysdig_event(sinsp_evt *evt, int pid, converter *sysdigC
         return;
     }
 
-    // filter out kindling-probe itself and pid in filter_pid
-    sinsp_threadinfo *evThreadInfo = evt->get_thread_info();
-    if (evThreadInfo->m_ptid == pid || evThreadInfo->m_pid == pid || evThreadInfo->m_pid == 0) {
-        return;
-    }
-
+    // filter out pid in filter_pid
     for (int i : filter_pid) {
-        if (i == evThreadInfo->m_pid) {
+        if (i == pid) {
             return;
         }
     }


### PR DESCRIPTION
use suppress_events_comm to filter out events from libscap;
filter out io-related events that do not contain message

Signed-off-by: sanyangji <songyujie@zju.edu.cn>