### PR TITLE
WIP: Pref/use a adapter to replace format processor to avoid recreate gauge during relabling

### DIFF
--- a/collector/consumer/exporter/otelexporter/adapter.go
+++ b/collector/consumer/exporter/otelexporter/adapter.go
@@ -1,0 +1,159 @@
+package otelexporter
+
+import (
+	"github.com/Kindling-project/kindling/collector/model"
+	"github.com/Kindling-project/kindling/collector/model/constlabels"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type valueType int
+
+type dictionary struct {
+	originKey string
+	newKey    string
+	valueType
+}
+
+const (
+	Int64  valueType = 0
+	String valueType = 1
+	Bool   valueType = 3
+)
+
+var entityCommonMetricsDicList = []dictionary{
+	{"", "", String},
+}
+
+var entityAggMetricsDicList = []dictionary{
+	{"", "", String},
+}
+
+var entityDetailMetricsDicList = []dictionary{
+	{"", "", String},
+}
+
+var topologyCommonMetricsDicList = []dictionary{
+	{"", "", String},
+}
+
+var topologyAggMetricsDicList = []dictionary{
+	{"", "", String},
+}
+
+var topologyDetailMetricsDicList = []dictionary{
+	{"", "", String},
+}
+
+var ServerEntity *metricAdapter = creatMetricAdapter(nil, entityCommonMetricsDicList, true, nil)
+
+type metricAdapter struct {
+	labelsMap            map[extraLabelsKey]realAttributes
+	paramMap             []attribute.KeyValue
+	metricsDicList       []dictionary
+	metricAggregationMap map[string]MetricAggregationKind
+	isServer             bool
+}
+
+type realAttributes struct {
+	paramMap       []attribute.KeyValue
+	metricsDicList []dictionary
+}
+
+type Protocol int
+
+type Granularity int
+
+const (
+	HTTP Protocol = iota
+	KAFKA
+)
+
+type extraLabelsKey struct {
+	protocol Protocol
+}
+
+type ProtocolLabels struct {
+	Protocol
+	labels  []attribute.KeyValue
+	dicList []dictionary
+}
+
+func withProtocols() []ProtocolLabels {
+	return []ProtocolLabels{
+		{
+			Protocol: HTTP,
+			labels:   nil,
+			dicList:  nil,
+		},
+	}
+}
+
+func creatMetricAdapter(
+	commonLabels []attribute.KeyValue,
+	metricsDicList []dictionary,
+	isServer bool,
+	protocols []ProtocolLabels,
+	extraLabels ...[]dictionary) *metricAdapter {
+	//TODO Value to labels
+	//serviceMetricDefaultLabels := make([]attribute.KeyValue, len(metricsDicList))
+	//for i := 0; i < len(metricsDicList); i++ {
+	//	serviceMetricDefaultLabels[i].Key = attribute.Key(metricsDicList[i].newKey)
+	//}
+	//return &metricAdapter{
+	//	paramMap:       append(serviceMetricDefaultLabels, commonLabels...),
+	//	metricsDicList: metricsDicList,
+	//	isServer:       isServer,
+	//}
+
+	baseLabels := make([]attribute.KeyValue, len(metricsDicList))
+	// baseLabels
+	for j := 0; j < len(metricsDicList); j++ {
+		baseLabels[j].Key = attribute.Key(metricsDicList[j].newKey)
+	}
+	// extraLabels
+	for j := 0; j < len(extraLabels); j++ {
+		for k := 0; k < len(extraLabels[j]); k++ {
+			baseLabels = append(baseLabels, attribute.KeyValue{
+				Key: attribute.Key(extraLabels[j][k].newKey),
+			})
+			metricsDicList = append(metricsDicList, extraLabels[j][k])
+		}
+	}
+
+	realAttributesMap := make(map[extraLabelsKey]realAttributes, len(protocols))
+	tmpAttributesKey := extraLabelsKey{}
+	for i := 0; i < len(protocols); i++ {
+		// Protocols
+		tmpAttributesKey.protocol = protocols[i].Protocol
+		realAttributesMap[tmpAttributesKey] = realAttributes{
+			metricsDicList: append(metricsDicList, protocols[i].dicList...),
+		}
+	}
+
+	return &metricAdapter{}
+}
+
+func (a *metricAdapter) adapter(baseLabels *model.AttributeMap) ([]attribute.KeyValue, error) {
+	//TODO protocol labels
+	for i := 0; i < len(a.metricsDicList); i++ {
+		switch a.metricsDicList[i].valueType {
+		case String:
+			a.paramMap[i].Value = attribute.StringValue(baseLabels.GetStringValue(a.metricsDicList[i].originKey))
+		case Int64:
+			a.paramMap[i].Value = attribute.Int64Value(baseLabels.GetIntValue(a.metricsDicList[i].originKey))
+		case Bool:
+			a.paramMap[i].Value = attribute.BoolValue(baseLabels.GetBoolValue(a.metricsDicList[i].originKey))
+		}
+	}
+	return a.paramMap, nil
+}
+
+func (a *metricAdapter) GetMeasurement(insFactory *instrumentFactory, gauges []model.Gauge) {
+	// TODO Label to Measurement
+	measurements := make([]metric.Measurement, 0, len(gauges))
+	for i := 0; i < len(gauges); i++ {
+		name := constlabels.ToKindlingMetricName(gauges[i].Name, a.isServer)
+		measurements = append(measurements, insFactory.getInstrument(name, a.metricAggregationMap[name]).Measurement(gauges[i].Value))
+	}
+}

--- a/collector/consumer/exporter/otelexporter/adapter.go
+++ b/collector/consumer/exporter/otelexporter/adapter.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Kindling-project/kindling/collector/model/constlabels"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"strconv"
 )
 
 type metricAdapter struct {
@@ -171,6 +172,11 @@ func (m *metricAdapterBuilder) withConstLabels(constLabels []attribute.KeyValue)
 	return m
 }
 
+func (m *metricAdapterBuilder) withAdjust(adjustFunc adjustLabels) *metricAdapterBuilder {
+	m.adjustLabels = append(m.adjustLabels, adjustFunc)
+	return m
+}
+
 func (m *metricAdapterBuilder) build() (*metricAdapter, error) {
 	labelsMap := make(map[extraLabelsKey]realAttributes, len(m.extraLabelsKey))
 	baseAndCommonParams := make([]attribute.KeyValue, 0, len(m.baseAndCommonLabelsDict))
@@ -236,6 +242,10 @@ func (m *metricAdapter) adapter(labels *model.AttributeMap, values []model.Gauge
 			attrs.paramMap[i].Value = attribute.Int64Value(labels.GetIntValue(attrs.metricsDicList[i].originKey))
 		case Bool:
 			attrs.paramMap[i].Value = attribute.BoolValue(labels.GetBoolValue(attrs.metricsDicList[i].originKey))
+		case FromInt64ToString:
+			attrs.paramMap[i].Value = attribute.StringValue(strconv.FormatInt(labels.GetIntValue(attrs.metricsDicList[i].originKey), 10))
+		case StrEmpty:
+			attrs.paramMap[i].Value = attribute.StringValue(constlabels.STR_EMPTY)
 		}
 	}
 

--- a/collector/consumer/exporter/otelexporter/baseAdapter.go
+++ b/collector/consumer/exporter/otelexporter/baseAdapter.go
@@ -1,0 +1,23 @@
+package otelexporter
+
+import "go.opentelemetry.io/otel/attribute"
+
+type BaseAdapterManager struct {
+	detailEntityAdapter   *metricAdapter
+	aggEntityAdapter      *metricAdapter
+	detailTopologyAdapter *metricAdapter
+	aggTopologyAdapter    *metricAdapter
+}
+
+func createBaseAdapterManager(metricAggMap map[string]MetricAggregationKind, constLabels []attribute.KeyValue) *BaseAdapterManager {
+	// TODO deal Error
+	aggEntityAdapter, _ := newMetricAdapterBuilder(entityMetricDicList, [][]dictionary{instanceMetricDicList},
+		metricAggMap, true).
+		withProtocols(entityProtocol, updateProtocolKey).
+		withConstLabels(constLabels).
+		build()
+
+	return &BaseAdapterManager{
+		aggEntityAdapter: aggEntityAdapter,
+	}
+}

--- a/collector/consumer/exporter/otelexporter/baseAdapter.go
+++ b/collector/consumer/exporter/otelexporter/baseAdapter.go
@@ -15,9 +15,17 @@ func createBaseAdapterManager(metricAggMap map[string]MetricAggregationKind, con
 		metricAggMap, true).
 		withProtocols(entityProtocol, updateProtocolKey).
 		withConstLabels(constLabels).
+		withAdjust(RemoveDstPodInfoForNonExternalAggTopology).
+		build()
+
+	detailEntityAdapter, _ := newMetricAdapterBuilder(entityMetricDicList, [][]dictionary{instanceMetricDicList, entityDetailMetricDicList},
+		metricAggMap, true).
+		withProtocols(entityProtocol, updateProtocolKey).
+		withConstLabels(constLabels).
 		build()
 
 	return &BaseAdapterManager{
-		aggEntityAdapter: aggEntityAdapter,
+		aggEntityAdapter:    aggEntityAdapter,
+		detailEntityAdapter: detailEntityAdapter,
 	}
 }

--- a/collector/consumer/exporter/otelexporter/config.go
+++ b/collector/consumer/exporter/otelexporter/config.go
@@ -25,3 +25,17 @@ type OtlpGrpcConfig struct {
 type StdoutConfig struct {
 	CollectPeriod time.Duration `mapstructure:"collect_period,omitempty"`
 }
+
+type AdapterConfig struct {
+	NeedTraceAsResourceSpan bool          `mapstructure:"need_trace_as_span"`
+	NeedTraceAsMetric       bool          `mapstructure:"need_trace_as_metric"`
+	NeedPodDetail           bool          `mapstructure:"need_pod_detail"`
+	StoreExternalSrcIP      bool          `mapstructure:"store_external_src_ip"`
+	SamplingRate            *SampleConfig `mapstructure:"sampling_rate"`
+}
+
+type SampleConfig struct {
+	NormalData int `mapstructure:"normal_data"`
+	SlowData   int `mapstructure:"slow_data"`
+	ErrorData  int `mapstructure:"error_data"`
+}

--- a/collector/consumer/exporter/otelexporter/dict.go
+++ b/collector/consumer/exporter/otelexporter/dict.go
@@ -1,0 +1,59 @@
+package otelexporter
+
+import (
+	"github.com/Kindling-project/kindling/collector/model/constlabels"
+)
+
+type Protocol int
+
+const (
+	empty Protocol = iota
+	HTTP
+	KAFKA
+	DNS
+	MYSQL
+	GRPC
+)
+
+type valueType int
+
+const (
+	Int64 valueType = iota
+	String
+	Bool
+)
+
+type dictionary struct {
+	newKey    string
+	originKey string
+	valueType
+}
+
+var instanceMetricDicList = []dictionary{
+	{constlabels.SrcIp, constlabels.SrcIp, String},
+	{constlabels.DstIp, constlabels.DstIp, String},
+	{constlabels.DstPort, constlabels.DstPort, Int64},
+}
+
+var entityMetricDicList = []dictionary{
+	{constlabels.DstNamespace, constlabels.Namespace, String},
+	{constlabels.WorkloadKind, constlabels.DstWorkloadKind, String},
+	{constlabels.WorkloadName, constlabels.DstWorkloadName, String},
+	{constlabels.Service, constlabels.DstService, String},
+	{constlabels.Protocol, constlabels.Protocol, String},
+}
+
+var entityProtocol = []extraLabelsParam{
+	{[]dictionary{
+		{constlabels.RequestContent, constlabels.ContentKey, String},
+		{constlabels.ResponseContent, constlabels.HttpStatusCode, Int64},
+	}, extraLabelsKey{HTTP}},
+	//{[]dictionary{
+	//	{constlabels.RequestContent, constlabels.ContentKey, String},
+	//	{constlabels.RequestContent, constlabels.HttpStatusCode, Int64},
+	//}, extraLabelsKey{KAFKA}},
+	//{[]dictionary{
+	//	{constlabels.RequestContent, constlabels.ContentKey, String},
+	//	{constlabels.RequestContent, constlabels.HttpStatusCode, Int64},
+	//}, extraLabelsKey{MYSQL}},
+}

--- a/collector/consumer/exporter/otelexporter/dict.go
+++ b/collector/consumer/exporter/otelexporter/dict.go
@@ -1,7 +1,9 @@
 package otelexporter
 
 import (
+	"github.com/Kindling-project/kindling/collector/model"
 	"github.com/Kindling-project/kindling/collector/model/constlabels"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type Protocol int
@@ -21,6 +23,8 @@ const (
 	Int64 valueType = iota
 	String
 	Bool
+	StrEmpty
+	FromInt64ToString
 )
 
 type dictionary struct {
@@ -35,25 +39,113 @@ var instanceMetricDicList = []dictionary{
 	{constlabels.DstPort, constlabels.DstPort, Int64},
 }
 
+var entityDetailMetricDicList = []dictionary{
+	{constlabels.Node, constlabels.DstNode, String},
+	{constlabels.Pod, constlabels.DstPod, String},
+	{constlabels.Container, constlabels.DstContainer, String},
+	{constlabels.ContainerId, constlabels.DstContainerId, String},
+}
+
 var entityMetricDicList = []dictionary{
-	{constlabels.DstNamespace, constlabels.Namespace, String},
+	{constlabels.Namespace, constlabels.DstNamespace, String},
 	{constlabels.WorkloadKind, constlabels.DstWorkloadKind, String},
 	{constlabels.WorkloadName, constlabels.DstWorkloadName, String},
 	{constlabels.Service, constlabels.DstService, String},
 	{constlabels.Protocol, constlabels.Protocol, String},
 }
 
+var topologyDetailMetricDicList = []dictionary{
+	{constlabels.SrcContainerId, constlabels.SrcContainerId, String},
+	{constlabels.SrcContainer, constlabels.SrcContainer, String},
+	{constlabels.DstContainerId, constlabels.DstContainerId, String},
+	{constlabels.DstContainer, constlabels.DstContainer, String},
+	{constlabels.DstNode, constlabels.DstNode, String},
+	{constlabels.DstPod, constlabels.DstPod, String},
+	{constlabels.SrcNode, constlabels.SrcNode, String},
+	{constlabels.SrcPod, constlabels.SrcPod, String},
+}
+
+var topologyMetricDicList = []dictionary{
+	{constlabels.SrcNamespace, constlabels.SrcNamespace, String},
+	{constlabels.SrcWorkloadKind, constlabels.SrcWorkloadKind, String},
+	{constlabels.SrcWorkloadName, constlabels.SrcWorkloadName, String},
+	{constlabels.SrcService, constlabels.SrcService, String},
+
+	{constlabels.DstNamespace, constlabels.DstNamespace, String},
+	{constlabels.DstWorkloadKind, constlabels.DstWorkloadKind, String},
+	{constlabels.DstWorkloadName, constlabels.DstWorkloadName, String},
+	{constlabels.DstService, constlabels.DstService, String},
+
+	{constlabels.DstNode, constlabels.DstNode, String},
+	{constlabels.DstPod, constlabels.DstPod, String},
+
+	{constlabels.Protocol, constlabels.Protocol, String},
+}
+
+func RemoveDstPodInfoForNonExternalAggTopology(labels *model.AttributeMap, attrs []attribute.KeyValue) []attribute.KeyValue {
+	if constlabels.IsNamespaceNotFound(labels.GetStringValue(constlabels.DstNamespace)) {
+		return attrs
+	} else {
+		for i := 0; i < len(attrs); i++ {
+			if attrs[i].Key == constlabels.DstNode || attrs[i].Key == constlabels.DstPod {
+				attrs[i].Value = attribute.StringValue(constlabels.STR_EMPTY)
+			}
+		}
+		return attrs
+	}
+}
+
 var entityProtocol = []extraLabelsParam{
 	{[]dictionary{
 		{constlabels.RequestContent, constlabels.ContentKey, String},
-		{constlabels.ResponseContent, constlabels.HttpStatusCode, Int64},
+		{constlabels.ResponseContent, constlabels.HttpStatusCode, FromInt64ToString},
 	}, extraLabelsKey{HTTP}},
-	//{[]dictionary{
-	//	{constlabels.RequestContent, constlabels.ContentKey, String},
-	//	{constlabels.RequestContent, constlabels.HttpStatusCode, Int64},
-	//}, extraLabelsKey{KAFKA}},
-	//{[]dictionary{
-	//	{constlabels.RequestContent, constlabels.ContentKey, String},
-	//	{constlabels.RequestContent, constlabels.HttpStatusCode, Int64},
-	//}, extraLabelsKey{MYSQL}},
+	{[]dictionary{
+		{constlabels.RequestContent, constlabels.KafkaTopic, String},
+		{constlabels.RequestContent, constlabels.STR_EMPTY, StrEmpty},
+	}, extraLabelsKey{KAFKA}},
+	{[]dictionary{
+		{constlabels.RequestContent, constlabels.ContentKey, String},
+		{constlabels.RequestContent, constlabels.SqlErrCode, FromInt64ToString},
+	}, extraLabelsKey{MYSQL}},
+	{[]dictionary{
+		{constlabels.RequestContent, constlabels.ContentKey, String},
+		{constlabels.RequestContent, constlabels.HttpStatusCode, FromInt64ToString},
+	}, extraLabelsKey{GRPC}},
+	{[]dictionary{
+		{constlabels.RequestContent, constlabels.DnsDomain, String},
+		{constlabels.RequestContent, constlabels.DnsRcode, FromInt64ToString},
+	}, extraLabelsKey{DNS}},
 }
+
+//
+//case http:
+//if isServer {
+//fillEntityHttpProtocolLabel(g)
+//} else {
+//fillTopologyHttpProtocolLabel(g)
+//}
+//case dns:
+//if isServer {
+//fillEntityDnsProtocolLabel(g)
+//} else {
+//fillTopologyDnsProtocolLabel(g)
+//}
+//case kafka:
+//if isServer {
+//fillEntityKafkaProtocolLabel(g)
+//} else {
+//fillTopologyKafkaProtocolLabel(g)
+//}
+//case mysql:
+//if isServer {
+//fillEntityMysqlProtocolLabel(g)
+//} else {
+//fillTopologyMysqlProtocolLabel(g)
+//}
+//case grpc:
+//if isServer {
+//fillEntityHttpProtocolLabel(g)
+//} else {
+//fillTopologyHttpProtocolLabel(g)
+//}

--- a/collector/consumer/exporter/otelexporter/inner_dictionary.go
+++ b/collector/consumer/exporter/otelexporter/inner_dictionary.go
@@ -1,0 +1,313 @@
+package otelexporter
+
+import (
+	"github.com/Kindling-project/kindling/collector/model"
+	"github.com/Kindling-project/kindling/collector/model/constlabels"
+	"github.com/Kindling-project/kindling/collector/model/constvalues"
+)
+
+const (
+	millToNano       = 1000000
+	GreenStatus      = "1"
+	YellowStatus     = "2"
+	RedStatus        = "3"
+	srcContainerId   = "src_containerid"
+	srcContainerName = "src_container_name"
+	dstContainerId   = "dst_containerid"
+	dstContainerName = "dst_container_name"
+)
+
+type gauges struct {
+	*model.GaugeGroup
+	targetValues []*model.Gauge
+	targetLabels *model.AttributeMap
+}
+
+func newGauges(g *model.GaugeGroup) *gauges {
+	// Since some operations modify the original data, a copy is used here instead of the original data (only shallow copy)
+	gaugeGroupCp := &model.GaugeGroup{
+		Name:      g.Name,
+		Values:    g.Values,
+		Labels:    g.Labels,
+		Timestamp: g.Timestamp,
+	}
+
+	return &gauges{
+		GaugeGroup:   gaugeGroupCp,
+		targetValues: make([]*model.Gauge, 0, len(g.Values)),
+		targetLabels: g.Labels,
+	}
+}
+
+func (g *gauges) isSlowOrError() bool {
+	return g.Labels.GetBoolValue(constlabels.IsSlow) || g.Labels.GetBoolValue(constlabels.IsError)
+}
+
+func (g gauges) getResult() *model.GaugeGroup {
+	return &model.GaugeGroup{
+		Name:      g.Name,
+		Values:    g.targetValues,
+		Labels:    g.targetLabels,
+		Timestamp: g.Timestamp,
+	}
+}
+
+type Relabel func(cfg *AdapterConfig, g *gauges)
+
+func (g gauges) Process(cfg *AdapterConfig, relabels ...Relabel) *model.GaugeGroup {
+	for i := 0; i < len(relabels); i++ {
+		relabels[i](cfg, &g)
+	}
+	return g.getResult()
+}
+
+func MetricName(cfg *AdapterConfig, g *gauges) {
+	for _, gauge := range g.Values {
+		if name := constlabels.ToKindlingMetricName(gauge.Name, g.Labels.GetBoolValue(constlabels.IsServer)); name != "" {
+			g.targetValues = append(g.targetValues, &model.Gauge{
+				Name:  name,
+				Value: gauge.Value,
+			})
+			//} else {
+			//	log.Debugf(nil, "Unused Metric Value：%s,dropped!", gauge.Name)
+		}
+	}
+}
+
+func TraceName(cfg *AdapterConfig, g *gauges) {
+	var requestDuration int64
+	for i := 0; i < len(g.Values); i++ {
+		if g.Values[i].Name == constvalues.RequestTotalTime {
+			requestDuration = g.Values[i].Value
+		}
+	}
+
+	g.targetValues = append(g.targetValues, &model.Gauge{
+		Name:  constlabels.ToKindlingTraceAsMetricName(),
+		Value: requestDuration,
+	})
+}
+
+func SpanName(cfg *AdapterConfig, g *gauges) {
+	g.Name = constvalues.SpanInfo
+}
+
+func ProtocolDetailMetricName(cfg *AdapterConfig, g *gauges) {
+	for _, gauge := range g.Values {
+		g.targetValues = append(g.targetValues, &model.Gauge{
+			Name:  constlabels.ToKindlingDetailMetricName(gauge.Name, g.Labels.GetStringValue(constlabels.Protocol)),
+			Value: gauge.Value,
+		})
+	}
+}
+
+func ServiceK8sInfo(cfg *AdapterConfig, g *gauges) {
+	if cfg.NeedPodDetail {
+		g.targetLabels.AddStringValue(constlabels.Node, g.Labels.GetStringValue(constlabels.DstNode))
+		g.targetLabels.AddStringValue(constlabels.Pod, g.Labels.GetStringValue(constlabels.DstPod))
+		g.targetLabels.AddStringValue(constlabels.Container, g.Labels.GetStringValue(constlabels.DstContainer))
+		g.targetLabels.AddStringValue(constlabels.ContainerId, g.Labels.GetStringValue(constlabels.DstContainerId))
+	}
+	g.targetLabels.AddStringValue(constlabels.Namespace, g.Labels.GetStringValue(constlabels.DstNamespace))
+	g.targetLabels.AddStringValue(constlabels.WorkloadKind, g.Labels.GetStringValue(constlabels.DstWorkloadKind))
+	g.targetLabels.AddStringValue(constlabels.WorkloadName, g.Labels.GetStringValue(constlabels.DstWorkloadName))
+	g.targetLabels.AddStringValue(constlabels.Service, g.Labels.GetStringValue(constlabels.DstService))
+}
+
+func TopologyTraceK8sInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.SrcNode, g.Labels.GetStringValue(constlabels.SrcNode))
+	g.targetLabels.AddStringValue(constlabels.SrcNamespace, g.Labels.GetStringValue(constlabels.SrcNamespace))
+	g.targetLabels.AddStringValue(constlabels.SrcWorkloadKind, g.Labels.GetStringValue(constlabels.SrcWorkloadKind))
+	g.targetLabels.AddStringValue(constlabels.SrcWorkloadName, g.Labels.GetStringValue(constlabels.SrcWorkloadName))
+	g.targetLabels.AddStringValue(constlabels.SrcService, g.Labels.GetStringValue(constlabels.SrcService))
+	g.targetLabels.AddStringValue(constlabels.SrcPod, g.Labels.GetStringValue(constlabels.SrcPod))
+
+	g.targetLabels.AddStringValue(constlabels.DstNode, g.Labels.GetStringValue(constlabels.DstNode))
+	g.targetLabels.AddStringValue(constlabels.DstNamespace, g.Labels.GetStringValue(constlabels.DstNamespace))
+	g.targetLabels.AddStringValue(constlabels.DstWorkloadKind, g.Labels.GetStringValue(constlabels.DstWorkloadKind))
+	g.targetLabels.AddStringValue(constlabels.DstWorkloadName, g.Labels.GetStringValue(constlabels.DstWorkloadName))
+	g.targetLabels.AddStringValue(constlabels.DstService, g.Labels.GetStringValue(constlabels.DstService))
+	g.targetLabels.AddStringValue(constlabels.DstPod, g.Labels.GetStringValue(constlabels.DstPod))
+}
+
+func TopologyK8sInfo(cfg *AdapterConfig, g *gauges) {
+	if cfg.NeedPodDetail {
+		TopologyTraceK8sInfo(cfg, g)
+	} else {
+		g.targetLabels.AddStringValue(constlabels.SrcNamespace, g.Labels.GetStringValue(constlabels.SrcNamespace))
+		g.targetLabels.AddStringValue(constlabels.SrcWorkloadKind, g.Labels.GetStringValue(constlabels.SrcWorkloadKind))
+		g.targetLabels.AddStringValue(constlabels.SrcWorkloadName, g.Labels.GetStringValue(constlabels.SrcWorkloadName))
+		g.targetLabels.AddStringValue(constlabels.SrcService, g.Labels.GetStringValue(constlabels.SrcService))
+
+		g.targetLabels.AddStringValue(constlabels.DstNamespace, g.Labels.GetStringValue(constlabels.DstNamespace))
+		g.targetLabels.AddStringValue(constlabels.DstWorkloadKind, g.Labels.GetStringValue(constlabels.DstWorkloadKind))
+		g.targetLabels.AddStringValue(constlabels.DstWorkloadName, g.Labels.GetStringValue(constlabels.DstWorkloadName))
+		g.targetLabels.AddStringValue(constlabels.DstService, g.Labels.GetStringValue(constlabels.DstService))
+
+		if constlabels.IsNamespaceNotFound(g.Labels.GetStringValue(constlabels.DstNamespace)) {
+			g.targetLabels.AddStringValue(constlabels.DstNode, g.Labels.GetStringValue(constlabels.DstNode))
+			g.targetLabels.AddStringValue(constlabels.DstPod, g.Labels.GetStringValue(constlabels.DstPod))
+		}
+	}
+}
+
+// SrcContainerInfo adds container level information to the input gauges if cfg.NeedPodDetail is enabled.
+func SrcContainerInfo(cfg *AdapterConfig, g *gauges) {
+	if cfg.NeedPodDetail {
+		g.targetLabels.AddStringValue(constlabels.SrcContainer, g.Labels.GetStringValue(constlabels.SrcContainer))
+		g.targetLabels.AddStringValue(constlabels.SrcContainerId, g.Labels.GetStringValue(constlabels.SrcContainerId))
+	}
+}
+
+// DstContainerInfo adds container level information to the input gauges if cfg.NeedPodDetail is enabled.
+func DstContainerInfo(cfg *AdapterConfig, g *gauges) {
+	if cfg.NeedPodDetail {
+		g.targetLabels.AddStringValue(constlabels.DstContainer, g.Labels.GetStringValue(constlabels.DstContainer))
+		g.targetLabels.AddStringValue(constlabels.DstContainerId, g.Labels.GetStringValue(constlabels.DstContainerId))
+	}
+}
+
+func ServiceInstanceInfo(cfg *AdapterConfig, g *gauges) {
+	if cfg.NeedPodDetail {
+		g.targetLabels.AddStringValue(constlabels.Ip, g.Labels.GetStringValue(constlabels.DstIp))
+		g.targetLabels.AddIntValue(constlabels.Port, g.Labels.GetIntValue(constlabels.DstPort))
+	}
+}
+
+func TopologyTraceInstanceInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.SrcIp, g.Labels.GetStringValue(constlabels.SrcIp))
+	DstInstanceInfo(cfg, g)
+}
+
+func TopologyInstanceInfo(cfg *AdapterConfig, g *gauges) {
+	if cfg.NeedPodDetail {
+		TopologyTraceInstanceInfo(cfg, g)
+	} else if constlabels.IsNamespaceNotFound(g.Labels.GetStringValue(constlabels.DstNamespace)) {
+		DstInstanceInfo(cfg, g)
+	}
+}
+
+func DstInstanceInfo(cfg *AdapterConfig, g *gauges) {
+	if g.Labels.GetStringValue(constlabels.DnatIp) != "" {
+		g.targetLabels.AddStringValue(constlabels.DstIp, g.Labels.GetStringValue(constlabels.DnatIp))
+	} else {
+		g.targetLabels.AddStringValue(constlabels.DstIp, g.Labels.GetStringValue(constlabels.DstIp))
+	}
+
+	if g.Labels.GetIntValue(constlabels.DnatPort) != -1 && g.Labels.GetIntValue(constlabels.DnatPort) != 0 {
+		g.targetLabels.AddIntValue(constlabels.DstPort, g.Labels.GetIntValue(constlabels.DnatPort))
+	} else {
+		g.targetLabels.AddIntValue(constlabels.DstPort, g.Labels.GetIntValue(constlabels.DstPort))
+	}
+}
+
+func SpanProtocolInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.Protocol, g.Labels.GetStringValue(constlabels.Protocol))
+	g.targetLabels.AddStringValue(constlabels.ContentKey, g.Labels.GetStringValue(constlabels.ContentKey))
+	fillSpanProtocolLabels(g, ProtocolType(g.Labels.GetStringValue(constlabels.Protocol)))
+}
+
+func ServiceProtocolInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.Protocol, g.Labels.GetStringValue(constlabels.Protocol))
+	fillCommonProtocolLabels(g, ProtocolType(g.Labels.GetStringValue(constlabels.Protocol)), true)
+}
+
+func TopologyProtocolInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.Protocol, g.Labels.GetStringValue(constlabels.Protocol))
+	fillCommonProtocolLabels(g, ProtocolType(g.Labels.GetStringValue(constlabels.Protocol)), false)
+}
+
+func ProtocolDetailInfo(cfg *AdapterConfig, g *gauges) {
+	fillKafkaMetricProtocolLabel(g)
+}
+
+func TraceStatusInfo(cfg *AdapterConfig, g *gauges) {
+	var requestSend, waitingTtfb, contentDownload, requestTotalTime int64
+	for i := 0; i < len(g.Values); i++ {
+		if g.Values[i].Name == constvalues.RequestSentTime {
+			requestSend = g.Values[i].Value
+		} else if g.Values[i].Name == constvalues.WaitingTtfbTime {
+			waitingTtfb = g.Values[i].Value
+		} else if g.Values[i].Name == constvalues.ContentDownloadTime {
+			contentDownload = g.Values[i].Value
+		} else if g.Values[i].Name == constvalues.RequestTotalTime {
+			requestTotalTime = g.Values[i].Value
+		}
+	}
+	g.targetLabels.AddStringValue(constlabels.RequestReqxferStatus, getSubStageStatus(requestSend))
+	g.targetLabels.AddStringValue(constlabels.RequestProcessingStatus, getSubStageStatus(waitingTtfb))
+	g.targetLabels.AddStringValue(constlabels.ResponseRspxferStatus, getSubStageStatus(contentDownload))
+	g.targetLabels.AddStringValue(constlabels.RequestDurationStatus, getRequestStatus(requestTotalTime))
+	g.targetLabels.AddBoolValue(constlabels.IsServer, g.Labels.GetBoolValue(constlabels.IsServer))
+}
+
+func getRequestStatus(requestLatency int64) string {
+	if requestLatency <= 800*millToNano {
+		return GreenStatus
+	} else if requestLatency >= 1500*millToNano {
+		return RedStatus
+	} else {
+		return YellowStatus
+	}
+}
+
+func getSubStageStatus(requestSendTime int64) string {
+	if requestSendTime <= 200*millToNano {
+		return GreenStatus
+	} else if requestSendTime >= 1000*millToNano {
+		return RedStatus
+	} else {
+		return YellowStatus
+	}
+}
+
+func traceSpanContainerInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(srcContainerName, g.Labels.GetStringValue(constlabels.SrcContainer))
+	g.targetLabels.AddStringValue(srcContainerId, g.Labels.GetStringValue(constlabels.SrcContainerId))
+	g.targetLabels.AddStringValue(dstContainerName, g.Labels.GetStringValue(constlabels.DstContainer))
+	g.targetLabels.AddStringValue(dstContainerId, g.Labels.GetStringValue(constlabels.DstContainerId))
+}
+
+func traceSpanInstanceInfo(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.SrcIp, g.Labels.GetStringValue(constlabels.SrcIp))
+	g.targetLabels.AddStringValue(constlabels.SrcPort, g.Labels.GetStringValue(constlabels.SrcPort))
+	DstInstanceInfo(cfg, g)
+}
+
+func traceSpanValuesToLabel(cfg *AdapterConfig, g *gauges) {
+	for i := 0; i < len(g.Values); i++ {
+		switch g.Values[i].Name {
+		case constvalues.RequestSentTime:
+			g.targetLabels.AddIntValue(constlabels.RequestSentNs, g.Values[i].Value)
+		case constvalues.WaitingTtfbTime:
+			g.targetLabels.AddIntValue(constlabels.WaitingTTfbNs, g.Values[i].Value)
+		case constvalues.ContentDownloadTime:
+			g.targetLabels.AddIntValue(constlabels.ContentDownloadNs, g.Values[i].Value)
+		case constvalues.RequestTotalTime:
+			g.targetLabels.AddIntValue(constlabels.RequestTotalNs, g.Values[i].Value)
+		case constvalues.RequestIo:
+			g.targetLabels.AddIntValue(constlabels.RequestIoBytes, g.Values[i].Value)
+		case constvalues.ResponseIo:
+			g.targetLabels.AddIntValue(constlabels.ResponseIoBytes, g.Values[i].Value)
+		}
+	}
+
+	g.targetLabels.AddIntValue(constlabels.IsServer, int64(If(g.Labels.GetBoolValue(constlabels.IsServer), 1, 0).(int)))
+	g.targetLabels.AddIntValue(constlabels.IsError, int64(If(g.Labels.GetBoolValue(constlabels.IsError), 1, 0).(int)))
+	g.targetLabels.AddIntValue(constlabels.IsSlow, int64(If(g.Labels.GetBoolValue(constlabels.IsSlow), 1, 0).(int)))
+
+	// TODO is_convergent
+	g.targetLabels.AddIntValue(constlabels.IsConvergent, 0)
+	g.targetLabels.AddIntValue(constlabels.Timestamp, int64(g.Timestamp/millToNano))
+}
+
+func If(condition bool, trueVal, falseVal interface{}) interface{} {
+	if condition {
+		return trueVal
+	}
+	return falseVal
+}
+
+func cleanSrcPort(cfg *AdapterConfig, g *gauges) {
+	g.targetLabels.RemoveAttribute(constlabels.SrcPort)
+}

--- a/collector/consumer/exporter/otelexporter/protocol.go
+++ b/collector/consumer/exporter/otelexporter/protocol.go
@@ -1,0 +1,141 @@
+package otelexporter
+
+import (
+	"github.com/Kindling-project/kindling/collector/model/constlabels"
+	"strconv"
+)
+
+type ProtocolType string
+
+const (
+	http  = "http"
+	http2 = "http2"
+	grpc  = "grpc"
+	dubbo = "dubbo"
+	dns   = "dns"
+	kafka = "kafka"
+	mysql = "mysql"
+)
+
+func fillSpecialProtocolLabels(g *gauges, protocol ProtocolType) {
+	switch protocol {
+	case kafka:
+		fillKafkaMetricProtocolLabel(g)
+	default:
+		// Do nothing
+	}
+}
+
+func fillSpanProtocolLabels(g *gauges, protocol ProtocolType) {
+	switch protocol {
+	case http:
+		fillSpanHttpProtocolLabel(g)
+	case dns:
+		fillSpanDNSProtocolLabel(g)
+	case mysql:
+		fillSpanMysqlProtocolLabel(g)
+	}
+}
+
+func fillSpanMysqlProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue("mysql.sql", g.Labels.GetStringValue(constlabels.Sql))
+	g.targetLabels.AddStringValue("mysql.error_code", strconv.FormatInt(g.Labels.GetIntValue(constlabels.SqlErrCode), 10))
+	g.targetLabels.AddStringValue("mysql.error_msg", g.Labels.GetStringValue(constlabels.SqlErrMsg))
+}
+
+func fillSpanDNSProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue("dns.domain", g.Labels.GetStringValue(constlabels.DnsDomain))
+	g.targetLabels.AddStringValue("dns.rcode", strconv.FormatInt(g.Labels.GetIntValue(constlabels.DnsRcode), 10))
+}
+
+func fillCommonProtocolLabels(g *gauges, protocol ProtocolType, isServer bool) {
+	switch protocol {
+	case http:
+		if isServer {
+			fillEntityHttpProtocolLabel(g)
+		} else {
+			fillTopologyHttpProtocolLabel(g)
+		}
+	case dns:
+		if isServer {
+			fillEntityDnsProtocolLabel(g)
+		} else {
+			fillTopologyDnsProtocolLabel(g)
+		}
+	case kafka:
+		if isServer {
+			fillEntityKafkaProtocolLabel(g)
+		} else {
+			fillTopologyKafkaProtocolLabel(g)
+		}
+	case mysql:
+		if isServer {
+			fillEntityMysqlProtocolLabel(g)
+		} else {
+			fillTopologyMysqlProtocolLabel(g)
+		}
+	case grpc:
+		if isServer {
+			fillEntityHttpProtocolLabel(g)
+		} else {
+			fillTopologyHttpProtocolLabel(g)
+		}
+	default:
+		// Do nothing ?
+	}
+}
+
+func fillEntityHttpProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.RequestContent, g.Labels.GetStringValue(constlabels.ContentKey))
+	g.targetLabels.AddStringValue(constlabels.ResponseContent, strconv.FormatInt(g.Labels.GetIntValue(constlabels.HttpStatusCode), 10))
+}
+
+func fillTopologyHttpProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.StatusCode, strconv.FormatInt(g.Labels.GetIntValue(constlabels.HttpStatusCode), 10))
+}
+
+func fillSpanHttpProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue("http.method", g.Labels.GetStringValue(constlabels.HttpMethod))
+	g.targetLabels.AddStringValue("http.endpoint", g.Labels.GetStringValue(constlabels.HttpUrl))
+	g.targetLabels.AddIntValue("http.status_code", g.Labels.GetIntValue(constlabels.HttpStatusCode))
+	g.targetLabels.AddStringValue("http.trace_id", g.Labels.GetStringValue(constlabels.HttpApmTraceId))
+	g.targetLabels.AddStringValue("http.trace_type", g.Labels.GetStringValue(constlabels.HttpApmTraceType))
+	g.targetLabels.AddStringValue("http.request_headers", g.Labels.GetStringValue(constlabels.HttpRequestPayload))
+	g.targetLabels.AddStringValue("http.request_body", "")
+	g.targetLabels.AddStringValue("http.response_headers", g.Labels.GetStringValue(constlabels.HttpResponsePayload))
+	g.targetLabels.AddStringValue("http.response_body", "")
+}
+
+func fillEntityDnsProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.RequestContent, g.Labels.GetStringValue(constlabels.DnsDomain))
+	g.targetLabels.AddStringValue(constlabels.ResponseContent, strconv.FormatInt(g.Labels.GetIntValue(constlabels.DnsRcode), 10))
+}
+
+func fillTopologyDnsProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.StatusCode, strconv.FormatInt(g.Labels.GetIntValue(constlabels.DnsRcode), 10))
+}
+
+func fillEntityKafkaProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.RequestContent, g.Labels.GetStringValue(constlabels.KafkaTopic))
+	g.targetLabels.AddStringValue(constlabels.ResponseContent, g.Labels.GetStringValue(constlabels.STR_EMPTY))
+}
+
+func fillTopologyKafkaProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.StatusCode, g.Labels.GetStringValue(constlabels.STR_EMPTY))
+}
+
+func fillEntityMysqlProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.RequestContent, g.Labels.GetStringValue(constlabels.ContentKey))
+	g.targetLabels.AddStringValue(constlabels.ResponseContent, strconv.FormatInt(g.Labels.GetIntValue(constlabels.SqlErrCode), 10))
+}
+
+func fillTopologyMysqlProtocolLabel(g *gauges) {
+	g.targetLabels.AddStringValue(constlabels.StatusCode, strconv.FormatInt(g.Labels.GetIntValue(constlabels.SqlErrCode), 10))
+}
+
+func fillKafkaMetricProtocolLabel(g *gauges) {
+	// TODO Missing Information Element
+	g.targetLabels.AddStringValue(constlabels.Topic, g.Labels.GetStringValue(constlabels.KafkaTopic))
+	//g.targetLabels.AddStringValue(constlabels.Operation,g.Labels.GetStringValue())
+	//g.targetLabels.AddStringValue(constlabels.ConsumerId, g.Labels.GetStringValue())
+}

--- a/collector/consumer/exporter/otelexporter/relabel_processor.go
+++ b/collector/consumer/exporter/otelexporter/relabel_processor.go
@@ -1,0 +1,104 @@
+package otelexporter
+
+import (
+	"github.com/Kindling-project/kindling/collector/component"
+	"github.com/Kindling-project/kindling/collector/consumer"
+	"github.com/Kindling-project/kindling/collector/consumer/processor"
+	"github.com/Kindling-project/kindling/collector/model"
+	"github.com/Kindling-project/kindling/collector/model/constlabels"
+	"go.uber.org/multierr"
+	"math/rand"
+)
+
+const ProcessorName = "kindlingformatprocessor"
+
+// RelabelProcessor generates new model.GaugeGroup according to the documentation.
+type RelabelProcessor struct {
+	cfg          *AdapterConfig
+	nextConsumer consumer.Consumer
+	telemetry    *component.TelemetryTools
+}
+
+func NewRelabelProcessor(cfg interface{}, telemetry *component.TelemetryTools, nextConsumer consumer.Consumer) processor.Processor {
+	processorCfg := cfg.(*AdapterConfig)
+	if processorCfg.SamplingRate == nil {
+		processorCfg.SamplingRate = &SampleConfig{
+			NormalData: 0,
+			SlowData:   100,
+			ErrorData:  100,
+		}
+	}
+	return &RelabelProcessor{
+		cfg:          processorCfg,
+		nextConsumer: nextConsumer,
+		telemetry:    telemetry,
+	}
+}
+
+func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
+	common := newGauges(gaugeGroup)
+
+	var traceErr error = nil
+	var spanErr error = nil
+
+	if r.cfg.NeedTraceAsMetric && common.isSlowOrError() {
+		// Trace as Metric
+		trace := newGauges(gaugeGroup)
+		traceErr = r.nextConsumer.Consume(trace.Process(r.cfg, TraceName, TopologyTraceInstanceInfo,
+			TopologyTraceK8sInfo, SrcContainerInfo, DstContainerInfo, ServiceProtocolInfo, TraceStatusInfo, cleanSrcPort))
+	}
+	if r.cfg.NeedTraceAsResourceSpan {
+		var isSample = false
+		randSeed := rand.Intn(100)
+		if common.isSlowOrError() {
+			if (randSeed < r.cfg.SamplingRate.SlowData) && gaugeGroup.Labels.GetBoolValue(constlabels.IsSlow) {
+				isSample = true
+			}
+			if (randSeed < r.cfg.SamplingRate.ErrorData) && gaugeGroup.Labels.GetBoolValue(constlabels.IsError) {
+				isSample = true
+			}
+		} else {
+			if randSeed < r.cfg.SamplingRate.NormalData {
+				isSample = true
+			}
+		}
+		if isSample {
+			// Trace As Span
+			span := newGauges(gaugeGroup)
+			spanErr = r.nextConsumer.Consume(span.Process(r.cfg, SpanName, traceSpanInstanceInfo,
+				TopologyTraceK8sInfo, traceSpanContainerInfo, SpanProtocolInfo, traceSpanValuesToLabel))
+		}
+	}
+
+	// The data when the field is Error is true and the error Type is 2, do not generate metric
+	errorType := gaugeGroup.Labels.GetIntValue(constlabels.ErrorType)
+	if errorType == constlabels.ConnectFail || errorType == constlabels.NoResponse {
+		return traceErr
+	}
+
+	if gaugeGroup.Labels.GetBoolValue(constlabels.IsServer) {
+		// Do not emit detail protocol metric at this version
+		//protocol := newGauges(gaugeGroup)
+		//protocolErr := r.nextConsumer.Consume(protocol.Process(r.cfg, ProtocolDetailMetricName, ServiceInstanceInfo, ServiceK8sInfo, ProtocolDetailInfo))
+		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, ServiceInstanceInfo, ServiceK8sInfo, ServiceProtocolInfo, cleanSrcPort))
+		var metricErr2 error
+		if r.cfg.StoreExternalSrcIP {
+			srcNamespace := gaugeGroup.Labels.GetStringValue(constlabels.SrcNamespace)
+			if srcNamespace == constlabels.ExternalClusterNamespace {
+				// Use data from server-side to generate a topology metric only when the namespace is EXTERNAL.
+				externalGaugeGroup := newGauges(gaugeGroup)
+				// Here we have to modify the field "IsServer" to generate the metric.
+				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, false)
+				metricErr2 = r.nextConsumer.Consume(externalGaugeGroup.Process(r.cfg, MetricName, TopologyInstanceInfo,
+					TopologyK8sInfo, DstContainerInfo, TopologyProtocolInfo, cleanSrcPort))
+				// In case of using the original data later, we reset the field "IsServer".
+				externalGaugeGroup.Labels.AddBoolValue(constlabels.IsServer, true)
+			}
+		}
+		return multierr.Combine(traceErr, spanErr, metricErr, metricErr2)
+	} else {
+		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, TopologyInstanceInfo, TopologyK8sInfo,
+			SrcContainerInfo, DstContainerInfo, TopologyProtocolInfo, cleanSrcPort))
+		return multierr.Combine(traceErr, metricErr)
+	}
+}

--- a/collector/consumer/exporter/otelexporter/relabel_processor.go
+++ b/collector/consumer/exporter/otelexporter/relabel_processor.go
@@ -80,7 +80,7 @@ func (r *RelabelProcessor) Consume(gaugeGroup *model.GaugeGroup) error {
 		// Do not emit detail protocol metric at this version
 		//protocol := newGauges(gaugeGroup)
 		//protocolErr := r.nextConsumer.Consume(protocol.Process(r.cfg, ProtocolDetailMetricName, ServiceInstanceInfo, ServiceK8sInfo, ProtocolDetailInfo))
-		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, ServiceInstanceInfo, ServiceK8sInfo, ServiceProtocolInfo, cleanSrcPort))
+		metricErr := r.nextConsumer.Consume(common.Process(r.cfg, MetricName, ServiceInstanceInfo, ServiceK8sInfo, ServiceProtocolInfo))
 		var metricErr2 error
 		if r.cfg.StoreExternalSrcIP {
 			srcNamespace := gaugeGroup.Labels.GetStringValue(constlabels.SrcNamespace)

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
@@ -303,3 +303,7 @@ func If(condition bool, trueVal, falseVal interface{}) interface{} {
 	}
 	return falseVal
 }
+
+func cleanSrcPort(cfg *Config, g *gauges) {
+	g.targetLabels.RemoveAttribute(constlabels.SrcPort)
+}

--- a/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
+++ b/collector/consumer/processor/kindlingformatprocessor/inner_dictionary.go
@@ -31,7 +31,7 @@ func newGauges(g *model.GaugeGroup) *gauges {
 	return &gauges{
 		GaugeGroup:   gaugeGroupCp,
 		targetValues: make([]*model.Gauge, 0, len(g.Values)),
-		targetLabels: model.NewAttributeMap(),
+		targetLabels: g.Labels,
 	}
 }
 


### PR DESCRIPTION
In the performance tests, we can see most memory malloc requests happened in format processor and otlp-exporter, which lead to a huge cost of GC. 
This PR is an implementation of a metric adapter in the otlp-exporter, which can use a static paramMap to relabel our gauges and pass this to the exporter.