### PR TITLE
Replace otel counter with atomic add for udsreceiver

### DIFF
--- a/collector/model/constnames/const.go
+++ b/collector/model/constnames/const.go
@@ -1,13 +1,23 @@
 package constnames
 
 const (
-	TcpCloseEvent          string = "tcp_close"
-	TcpRcvEstablishedEvent string = "tcp_rcv_established"
-	TcpDropEvent           string = "tcp_drop"
-	TcpRetransmitSkbEvent  string = "tcp_retransmit_skb"
+	ReadEvent     = "read"
+	WriteEvent    = "write"
+	ReadvEvent    = "readv"
+	WritevEvent   = "writev"
+	SendToEvent   = "sendto"
+	RecvFromEvent = "recvfrom"
+	SendMsgEvent  = "sendmsg"
+	RecvMsgEvent  = "recvmsg"
 
-	GrpcUprobeEvent          string = "grpc_uprobe"
-	NetRequestGaugeGroupName        = "net_request_gauge_group"
-	TcpGaugeGroupName               = "tcp_metric_gauge_group"
-	NodeGaugeGroupName              = "node_metric_gauge_group"
+	TcpCloseEvent          = "tcp_close"
+	TcpRcvEstablishedEvent = "tcp_rcv_established"
+	TcpDropEvent           = "tcp_drop"
+	TcpRetransmitSkbEvent  = "tcp_retransmit_skb"
+	OtherEvent             = "other"
+
+	GrpcUprobeEvent          = "grpc_uprobe"
+	NetRequestGaugeGroupName = "net_request_gauge_group"
+	TcpGaugeGroupName        = "tcp_metric_gauge_group"
+	NodeGaugeGroupName       = "node_metric_gauge_group"
 )

--- a/collector/receiver/udsreceiver/metrics.go
+++ b/collector/receiver/udsreceiver/metrics.go
@@ -1,17 +1,99 @@
 package udsreceiver
 
 import (
+	"context"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"sync"
+	"sync/atomic"
 )
 
 var once sync.Once
-var globalEventSentCounter metric.Int64Counter
 
 const eventReceivedMetric = "kindling_telemetry_udsreceiver_events_total"
 
-func newSelfMetrics(meterProvider metric.MeterProvider) {
+func newSelfMetrics(meterProvider metric.MeterProvider, counter eventCounter) {
 	once.Do(func() {
-		globalEventSentCounter = metric.Must(meterProvider.Meter("kindling")).NewInt64Counter(eventReceivedMetric)
+		meter := metric.Must(meterProvider.Meter("kindling"))
+		meter.NewInt64CounterObserver(eventReceivedMetric,
+			func(ctx context.Context, result metric.Int64ObserverResult) {
+				for name, value := range counter.getStats() {
+					result.Observe(value, attribute.String("name", name))
+				}
+			})
 	})
+}
+
+type eventCounter interface {
+	add(name string, value int64)
+	getStats() map[string]int64
+}
+
+type stats struct {
+	read              int64
+	write             int64
+	readv             int64
+	writev            int64
+	sendTo            int64
+	recvFrom          int64
+	sendMsg           int64
+	recvMsg           int64
+	grpcUprobe        int64
+	tcpClose          int64
+	tcpRcvEstablished int64
+	tcpDrop           int64
+	tcpRetransmitSkb  int64
+	other             int64
+}
+
+func (i *stats) add(name string, value int64) {
+	switch name {
+	case "read":
+		atomic.AddInt64(&i.read, value)
+	case "write":
+		atomic.AddInt64(&i.write, value)
+	case "readv":
+		atomic.AddInt64(&i.readv, value)
+	case "writev":
+		atomic.AddInt64(&i.writev, value)
+	case "sendto":
+		atomic.AddInt64(&i.sendTo, value)
+	case "recvfrom":
+		atomic.AddInt64(&i.recvFrom, value)
+	case "sendmsg":
+		atomic.AddInt64(&i.sendMsg, value)
+	case "recvmsg":
+		atomic.AddInt64(&i.recvMsg, value)
+	case "grpc_uprobe":
+		atomic.AddInt64(&i.grpcUprobe, value)
+	case "tcp_close":
+		atomic.AddInt64(&i.tcpClose, value)
+	case "tcp_rcv_established":
+		atomic.AddInt64(&i.tcpRcvEstablished, value)
+	case "tcp_drop":
+		atomic.AddInt64(&i.tcpDrop, value)
+	case "tcp_retransmit_skb":
+		atomic.AddInt64(&i.tcpRetransmitSkb, value)
+	default:
+		atomic.AddInt64(&i.other, value)
+	}
+}
+
+func (i *stats) getStats() map[string]int64 {
+	ret := make(map[string]int64, 14)
+	ret["read"] = atomic.LoadInt64(&i.read)
+	ret["write"] = atomic.LoadInt64(&i.write)
+	ret["readv"] = atomic.LoadInt64(&i.readv)
+	ret["writev"] = atomic.LoadInt64(&i.writev)
+	ret["sendto"] = atomic.LoadInt64(&i.sendTo)
+	ret["recvfrom"] = atomic.LoadInt64(&i.recvFrom)
+	ret["sendmsg"] = atomic.LoadInt64(&i.sendMsg)
+	ret["recvmsg"] = atomic.LoadInt64(&i.recvMsg)
+	ret["grpc_uprobe"] = atomic.LoadInt64(&i.grpcUprobe)
+	ret["tcp_close"] = atomic.LoadInt64(&i.tcpClose)
+	ret["tcp_rcv_established"] = atomic.LoadInt64(&i.tcpRcvEstablished)
+	ret["tcp_drop"] = atomic.LoadInt64(&i.tcpClose)
+	ret["tcp_retransmit_skb"] = atomic.LoadInt64(&i.tcpRetransmitSkb)
+	ret["other"] = atomic.LoadInt64(&i.other)
+	return ret
 }

--- a/collector/receiver/udsreceiver/metrics.go
+++ b/collector/receiver/udsreceiver/metrics.go
@@ -2,6 +2,7 @@ package udsreceiver
 
 import (
 	"context"
+	"github.com/Kindling-project/kindling/collector/model/constnames"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"sync"
@@ -48,31 +49,31 @@ type stats struct {
 
 func (i *stats) add(name string, value int64) {
 	switch name {
-	case "read":
+	case constnames.ReadEvent:
 		atomic.AddInt64(&i.read, value)
-	case "write":
+	case constnames.WriteEvent:
 		atomic.AddInt64(&i.write, value)
-	case "readv":
+	case constnames.ReadvEvent:
 		atomic.AddInt64(&i.readv, value)
-	case "writev":
+	case constnames.WritevEvent:
 		atomic.AddInt64(&i.writev, value)
-	case "sendto":
+	case constnames.SendToEvent:
 		atomic.AddInt64(&i.sendTo, value)
-	case "recvfrom":
+	case constnames.RecvFromEvent:
 		atomic.AddInt64(&i.recvFrom, value)
-	case "sendmsg":
+	case constnames.SendMsgEvent:
 		atomic.AddInt64(&i.sendMsg, value)
-	case "recvmsg":
+	case constnames.RecvMsgEvent:
 		atomic.AddInt64(&i.recvMsg, value)
-	case "grpc_uprobe":
+	case constnames.GrpcUprobeEvent:
 		atomic.AddInt64(&i.grpcUprobe, value)
-	case "tcp_close":
+	case constnames.TcpCloseEvent:
 		atomic.AddInt64(&i.tcpClose, value)
-	case "tcp_rcv_established":
+	case constnames.TcpRcvEstablishedEvent:
 		atomic.AddInt64(&i.tcpRcvEstablished, value)
-	case "tcp_drop":
+	case constnames.TcpDropEvent:
 		atomic.AddInt64(&i.tcpDrop, value)
-	case "tcp_retransmit_skb":
+	case constnames.TcpRetransmitSkbEvent:
 		atomic.AddInt64(&i.tcpRetransmitSkb, value)
 	default:
 		atomic.AddInt64(&i.other, value)
@@ -81,19 +82,19 @@ func (i *stats) add(name string, value int64) {
 
 func (i *stats) getStats() map[string]int64 {
 	ret := make(map[string]int64, 14)
-	ret["read"] = atomic.LoadInt64(&i.read)
-	ret["write"] = atomic.LoadInt64(&i.write)
-	ret["readv"] = atomic.LoadInt64(&i.readv)
-	ret["writev"] = atomic.LoadInt64(&i.writev)
-	ret["sendto"] = atomic.LoadInt64(&i.sendTo)
-	ret["recvfrom"] = atomic.LoadInt64(&i.recvFrom)
-	ret["sendmsg"] = atomic.LoadInt64(&i.sendMsg)
-	ret["recvmsg"] = atomic.LoadInt64(&i.recvMsg)
-	ret["grpc_uprobe"] = atomic.LoadInt64(&i.grpcUprobe)
-	ret["tcp_close"] = atomic.LoadInt64(&i.tcpClose)
-	ret["tcp_rcv_established"] = atomic.LoadInt64(&i.tcpRcvEstablished)
-	ret["tcp_drop"] = atomic.LoadInt64(&i.tcpClose)
-	ret["tcp_retransmit_skb"] = atomic.LoadInt64(&i.tcpRetransmitSkb)
-	ret["other"] = atomic.LoadInt64(&i.other)
+	ret[constnames.ReadEvent] = atomic.LoadInt64(&i.read)
+	ret[constnames.WriteEvent] = atomic.LoadInt64(&i.write)
+	ret[constnames.ReadvEvent] = atomic.LoadInt64(&i.readv)
+	ret[constnames.WritevEvent] = atomic.LoadInt64(&i.writev)
+	ret[constnames.SendToEvent] = atomic.LoadInt64(&i.sendTo)
+	ret[constnames.RecvFromEvent] = atomic.LoadInt64(&i.recvFrom)
+	ret[constnames.SendMsgEvent] = atomic.LoadInt64(&i.sendMsg)
+	ret[constnames.RecvMsgEvent] = atomic.LoadInt64(&i.recvMsg)
+	ret[constnames.GrpcUprobeEvent] = atomic.LoadInt64(&i.grpcUprobe)
+	ret[constnames.TcpCloseEvent] = atomic.LoadInt64(&i.tcpClose)
+	ret[constnames.TcpRcvEstablishedEvent] = atomic.LoadInt64(&i.tcpRcvEstablished)
+	ret[constnames.TcpCloseEvent] = atomic.LoadInt64(&i.tcpClose)
+	ret[constnames.TcpRetransmitSkbEvent] = atomic.LoadInt64(&i.tcpRetransmitSkb)
+	ret[constnames.OtherEvent] = atomic.LoadInt64(&i.other)
 	return ret
 }

--- a/collector/receiver/udsreceiver/metrics_test.go
+++ b/collector/receiver/udsreceiver/metrics_test.go
@@ -2,6 +2,7 @@ package udsreceiver
 
 import (
 	"context"
+	"github.com/Kindling-project/kindling/collector/model/constnames"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/metric"
@@ -26,8 +27,10 @@ func runTest(counter eventCounter, workerNum int, loopNum int) {
 	wg.Wait()
 }
 
-var eventLists = []string{"read", "write", "readv", "writev", "sendto", "recvfrom", "sendmsg", "recvmsg",
-	"grpc_uprobe", "tcp_close", "tcp_rcv_established", "tcp_drop", "tcp_retransmit_skb", "another_event"}
+var eventLists = []string{constnames.ReadEvent, constnames.WriteEvent, constnames.ReadvEvent, constnames.WritevEvent,
+	constnames.SendToEvent, constnames.RecvFromEvent, constnames.SendMsgEvent, constnames.RecvMsgEvent,
+	constnames.GrpcUprobeEvent, constnames.TcpCloseEvent, constnames.TcpRcvEstablishedEvent, constnames.TcpDropEvent,
+	constnames.TcpRetransmitSkbEvent, "another_event"}
 
 func runRecordCounter(loopNum int, counter eventCounter) {
 	for i := 0; i < loopNum; i++ {

--- a/collector/receiver/udsreceiver/metrics_test.go
+++ b/collector/receiver/udsreceiver/metrics_test.go
@@ -1,0 +1,187 @@
+package udsreceiver
+
+import (
+	"context"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+	"go.opentelemetry.io/otel/metric"
+	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
+	otelprocessor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
+	selector "go.opentelemetry.io/otel/sdk/metric/selector/simple"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func runTest(counter eventCounter, workerNum int, loopNum int) {
+	wg := sync.WaitGroup{}
+	for i := 0; i < workerNum; i++ {
+		wg.Add(1)
+		go func() {
+			runRecordCounter(loopNum, counter)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+var eventLists = []string{"read", "write", "readv", "writev", "sendto", "recvfrom", "sendmsg", "recvmsg",
+	"grpc_uprobe", "tcp_close", "tcp_rcv_established", "tcp_drop", "tcp_retransmit_skb", "another_event"}
+
+func runRecordCounter(loopNum int, counter eventCounter) {
+	for i := 0; i < loopNum; i++ {
+		for _, name := range eventLists {
+			counter.add(name, 1)
+		}
+	}
+}
+
+func assertTest(t *testing.T, counter eventCounter, workerNum int, loopNum int) {
+	runTest(counter, workerNum, loopNum)
+	expectedNum := workerNum * loopNum
+	for _, value := range counter.getStats() {
+		if value != int64(expectedNum) {
+			t.Errorf("The result is expected to be %d, but got %d", expectedNum, value)
+		}
+	}
+}
+
+func TestCounterMutexMap(t *testing.T) {
+	counter := &mutexMap{m: make(map[string]int64)}
+	assertTest(t, counter, 5, 100000)
+}
+
+func TestCounterRwMutexMap(t *testing.T) {
+	counter := &rwMutexMap{m: make(map[string]int64)}
+	assertTest(t, counter, 5, 100000)
+}
+
+func TestCounterIntCombination(t *testing.T) {
+	counter := &stats{}
+	assertTest(t, counter, 5, 100000)
+}
+
+func BenchmarkCounterMutexMap(b *testing.B) {
+	counter := &mutexMap{m: make(map[string]int64)}
+	initOtelCounterObserver(counter)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runTest(counter, 5, 1000)
+	}
+}
+
+func BenchmarkCounterRwMutexMap(b *testing.B) {
+	counter := &rwMutexMap{m: make(map[string]int64)}
+	initOtelCounterObserver(counter)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runTest(counter, 5, 1000)
+	}
+}
+
+func BenchmarkCounterIntCombination(b *testing.B) {
+	counter := &stats{}
+	initOtelCounterObserver(counter)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runTest(counter, 5, 1000)
+	}
+}
+
+func BenchmarkCounterOtelCounter(b *testing.B) {
+	counter := newOtelRecorder()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runTest(counter, 5, 1000)
+	}
+}
+
+// It's not practical to implement with sync.Map,
+// because you still need to lock the value when increasing it.
+// type syncMap struct {
+// 	m sync.Map
+// 	mutex sync.Mutex
+// }
+
+type mutexMap struct {
+	m     map[string]int64
+	mutex sync.Mutex
+}
+
+func (m *mutexMap) add(name string, value int64) {
+	m.mutex.Lock()
+	v := m.m[name]
+	m.m[name] = v + value
+	m.mutex.Unlock()
+}
+func (m *mutexMap) getStats() map[string]int64 {
+	m.mutex.Lock()
+	ret := make(map[string]int64, len(m.m))
+	for k, v := range m.m {
+		ret[k] = v
+	}
+	m.mutex.Unlock()
+	return ret
+}
+
+type rwMutexMap struct {
+	m     map[string]int64
+	mutex sync.RWMutex
+}
+
+func (m *rwMutexMap) add(name string, value int64) {
+	m.mutex.Lock()
+	v := m.m[name]
+	m.m[name] = v + value
+	m.mutex.Unlock()
+}
+func (m *rwMutexMap) getStats() map[string]int64 {
+	m.mutex.RLock()
+	ret := make(map[string]int64, len(m.m))
+	for k, v := range m.m {
+		ret[k] = v
+	}
+	m.mutex.RUnlock()
+	return ret
+}
+
+type otelRecorder struct {
+	otelCounter metric.Int64Counter
+}
+
+func newOtelRecorder() *otelRecorder {
+	meter := initOpentelemetry()
+	return &otelRecorder{otelCounter: meter.NewInt64Counter("event_counter_total")}
+}
+func (m *otelRecorder) add(name string, value int64) {
+	m.otelCounter.Add(context.Background(), value, attribute.String("name", name))
+}
+func (m *otelRecorder) getStats() map[string]int64 {
+	return nil
+}
+
+func initOpentelemetry() metric.MeterMust {
+	devNullWriter, _ := os.Open(os.DevNull)
+	exp, _ := stdoutmetric.New(stdoutmetric.WithWriter(devNullWriter))
+
+	cont := controller.New(
+		otelprocessor.NewFactory(selector.NewWithInexpensiveDistribution(), exp),
+		controller.WithExporter(exp),
+		controller.WithCollectPeriod(100*time.Millisecond),
+	)
+	_ = cont.Start(context.Background())
+	return metric.Must(cont.Meter("kindling"))
+}
+
+func initOtelCounterObserver(counter eventCounter) {
+	meter := initOpentelemetry()
+	meter.NewInt64CounterObserver("event_counter_total",
+		func(ctx context.Context, result metric.Int64ObserverResult) {
+			metrics := counter.getStats()
+			for name, value := range metrics {
+				result.Observe(value, attribute.String("name", name))
+			}
+		})
+}

--- a/collector/receiver/udsreceiver/udsreceiver.go
+++ b/collector/receiver/udsreceiver/udsreceiver.go
@@ -1,7 +1,6 @@
 package udsreceiver
 
 import (
-	"context"
 	analyzerpackage "github.com/Kindling-project/kindling/collector/analyzer"
 	"github.com/Kindling-project/kindling/collector/analyzer/network"
 	"github.com/Kindling-project/kindling/collector/analyzer/tcpmetricanalyzer"
@@ -12,7 +11,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/receiver"
 	"github.com/gogo/protobuf/proto"
 	zmq "github.com/pebbe/zmq4"
-	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"os"
@@ -36,6 +34,7 @@ type UdsReceiver struct {
 	shutdownWG      sync.WaitGroup
 	shutdwonState   bool
 	telemetry       *component.TelemetryTools
+	stats           eventCounter
 }
 
 type Config struct {
@@ -104,12 +103,14 @@ func NewUdsReceiver(config interface{}, telemetry *component.TelemetryTools, ana
 	if !ok {
 		telemetry.Logger.Sugar().Panicf("Cannot convert [%s] config", Uds)
 	}
-	newSelfMetrics(telemetry.MeterProvider)
-	return &UdsReceiver{
+	udsReceiver := &UdsReceiver{
 		cfg:             cfg,
 		analyzerManager: analyzerManager,
 		telemetry:       telemetry,
+		stats:           &stats{},
 	}
+	newSelfMetrics(telemetry.MeterProvider, udsReceiver.stats)
+	return udsReceiver
 }
 
 func (r *UdsReceiver) startZeroMqPull() error {
@@ -227,7 +228,7 @@ func (r *UdsReceiver) Shutdown() error {
 func (r *UdsReceiver) SendToNextConsumer(events *model.KindlingEventList) error {
 	// TODO: Decouple dispatching logic from receiver and conduct it at analyzerManager via configuration
 	for _, evt := range events.KindlingEventList {
-		globalEventSentCounter.Add(context.Background(), 1, attribute.String("name", evt.Name))
+		r.stats.add(evt.Name, 1)
 		var analyzer analyzerpackage.Analyzer
 		var isFound bool
 		switch evt.Name {


### PR DESCRIPTION
This optimization will bring small performance improvements to the whole process. But for the counter, this change could reduce the duration per operation to the previous 4%. The benchmark result is the following.

### Unit test
```
go test  -v metrics_test.go metrics.go

=== RUN   TestCounterMutexMap
--- PASS: TestCounterMutexMap (0.63s)
=== RUN   TestCounterRwMutexMap
--- PASS: TestCounterRwMutexMap (0.81s)
=== RUN   TestCounterIntCombination
--- PASS: TestCounterIntCombination (0.08s)
PASS
ok      command-line-arguments  2.970s
```

### Benchmark test
```
go test -bench=. metrics_test.go metrics.go

goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-6267U CPU @ 2.90GHz
BenchmarkCounterMutexMap-4                   219           5518793 ns/op
BenchmarkCounterRwMutexMap-4                 168           7165279 ns/op
BenchmarkCounterIntCombination-4            1394            769026 ns/op
BenchmarkCounterOtelCounter-4                 52          23431484 ns/op
PASS
ok      command-line-arguments  8.938s
```

### Conclusion
The benchmark shows that Opentelemetry-go SDK behaves badly on performance when compared with local trivial counters. It indicates that we should rethink whether the `otelexporter` is appropriate for the aggregation scenario.