### PR TITLE
Fix MultiTopics in kafka payload will be discerned as NOSUPPORT

### DIFF
--- a/collector/analyzer/network/network_analyzer_test.go
+++ b/collector/analyzer/network/network_analyzer_test.go
@@ -3,10 +3,11 @@ package network
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/Kindling-project/kindling/collector/component"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/Kindling-project/kindling/collector/component"
 
 	"github.com/Kindling-project/kindling/collector/consumer"
 	"github.com/Kindling-project/kindling/collector/model"
@@ -42,6 +43,9 @@ func TestKafkaProtocol(t *testing.T) {
 
 	testProtocol(t, "kafka/consumer-event.yml",
 		"kafka/consumer-trace-fetch-split.yml")
+
+	testProtocol(t, "kafka/consumer-event.yml",
+		"kafka/consumer-trace-fetch-multi-topics.yml")
 }
 
 type NopProcessor struct {

--- a/collector/analyzer/network/protocol/kafka/kafka_api.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_api.go
@@ -65,7 +65,7 @@ const (
 )
 
 var kafka_apis = map[int]apiVersion{
-	_apiProduce:                      {1, 9},
+	_apiProduce:                      {0, 9},
 	_apiFetch:                        {0, 12},
 	_apiListOffsets:                  {0, 7},
 	_apiMetadata:                     {0, 11},

--- a/collector/analyzer/network/protocol/kafka/kafka_request_fetch.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request_fetch.go
@@ -14,12 +14,10 @@ func fastfailRequestFetch() protocol.FastFailFn {
 func parseRequestFetch() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		var (
-			offset       int
-			err          error
-			topicNum     int32
-			topicName    string
-			partitionNum int32
-			partition    int32
+			offset    int
+			err       error
+			topicNum  int32
+			topicName string
 		)
 		version := message.GetIntAttribute(constlabels.KafkaVersion)
 		compact := version >= 12
@@ -36,20 +34,16 @@ func parseRequestFetch() protocol.ParsePkgFn {
 			offset += 8 // session_id, session_epoch
 		}
 
-		if offset, err = message.ReadArraySize(offset, compact, &topicNum); err != nil || topicNum != 1 {
+		if offset, err = message.ReadArraySize(offset, compact, &topicNum); err != nil {
 			return false, true
 		}
-		if offset, err = message.ReadString(offset, compact, &topicName); err != nil {
-			return false, true
+		if topicNum > 0 {
+			if _, err = message.ReadString(offset, compact, &topicName); err != nil {
+				return false, true
+			}
+			// Read First TopicName
+			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
-		if offset, err = message.ReadArraySize(offset, compact, &partitionNum); err != nil || partitionNum != 1 {
-			return false, true
-		}
-		if _, err = message.ReadInt32(offset, &partition); err != nil {
-			return false, true
-		}
-		message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
-		message.AddIntAttribute(constlabels.KafkaPartition, int64(partition))
 
 		return true, true
 	}

--- a/collector/analyzer/network/protocol/kafka/kafka_request_fetch.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request_fetch.go
@@ -41,7 +41,11 @@ func parseRequestFetch() protocol.ParsePkgFn {
 			if _, err = message.ReadString(offset, compact, &topicName); err != nil {
 				return false, true
 			}
-			// Read First TopicName
+			/*
+				TODO Get all topicNames(Ver 0~12)
+				There is not enough cases to cover multi-topics, just read first topicName.
+				Since Version 13, topicName will be repalced with topicId as uuid, this will not got.
+			*/
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 

--- a/collector/analyzer/network/protocol/kafka/kafka_request_fetch.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request_fetch.go
@@ -42,9 +42,13 @@ func parseRequestFetch() protocol.ParsePkgFn {
 				return false, true
 			}
 			/*
-				TODO Get all topicNames(Ver 0~12)
-				There is not enough cases to cover multi-topics, just read first topicName.
-				Since Version 13, topicName will be repalced with topicId as uuid, this will not got.
+				Based on following case, we	just read first topicName.
+
+				1. The payload is substr with fixed length(1K), it's not able to get all topic names
+				2. Even if we get enough length for payload, the parser will take more performance cost
+				3. There is not enough cases to cover multi-topics
+
+				Since version 13, topicName will be repalced with topicId as uuid, therefore topicName is not able to be got.
 			*/
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}

--- a/collector/analyzer/network/protocol/kafka/kafka_request_produce.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request_produce.go
@@ -38,10 +38,7 @@ func parseRequestProduce() protocol.ParsePkgFn {
 			if _, err = message.ReadString(offset, compact, &topicName); err != nil {
 				return false, true
 			}
-			/*
-				TODO Get all topicNames
-				There is not enough cases to cover multi-topics, just read first topicName.
-			*/
+			// Get TopicName
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 		return true, true

--- a/collector/analyzer/network/protocol/kafka/kafka_request_produce.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request_produce.go
@@ -14,12 +14,10 @@ func fastfailRequestProduce() protocol.FastFailFn {
 func parseRequestProduce() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		var (
-			offset       int
-			err          error
-			topicNum     int32
-			topicName    string
-			partitionNum int32
-			partition    int32
+			offset    int
+			err       error
+			topicNum  int32
+			topicName string
 		)
 		version := message.GetIntAttribute(constlabels.KafkaVersion)
 		compact := version >= 9
@@ -28,27 +26,21 @@ func parseRequestProduce() protocol.ParsePkgFn {
 		if version >= 3 {
 			var transactionId string
 			if offset, err = message.ReadNullableString(offset, compact, &transactionId); err != nil {
-				//TODO maybe pass this error to caller if we need output the exact error msg to log
 				return false, true
 			}
 		}
 		// acks, timeout_ms
 		offset += 6
-		if offset, err = message.ReadArraySize(offset, compact, &topicNum); err != nil || topicNum != 1 {
+		if offset, err = message.ReadArraySize(offset, compact, &topicNum); err != nil {
 			return false, true
 		}
-		if offset, err = message.ReadString(offset, compact, &topicName); err != nil {
-			return false, true
+		if topicNum > 0 {
+			if _, err = message.ReadString(offset, compact, &topicName); err != nil {
+				return false, true
+			}
+			// Read First TopicName
+			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
-		if offset, err = message.ReadArraySize(offset, compact, &partitionNum); err != nil || partitionNum != 1 {
-			return false, true
-		}
-		if _, err = message.ReadInt32(offset, &partition); err != nil {
-			return false, true
-		}
-
-		message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
-		message.AddIntAttribute(constlabels.KafkaPartition, int64(partition))
 		return true, true
 	}
 }

--- a/collector/analyzer/network/protocol/kafka/kafka_request_produce.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_request_produce.go
@@ -38,7 +38,10 @@ func parseRequestProduce() protocol.ParsePkgFn {
 			if _, err = message.ReadString(offset, compact, &topicName); err != nil {
 				return false, true
 			}
-			// Read First TopicName
+			/*
+				TODO Get all topicNames
+				There is not enough cases to cover multi-topics, just read first topicName.
+			*/
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 		return true, true

--- a/collector/analyzer/network/protocol/kafka/kafka_response_fetch.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_response_fetch.go
@@ -19,7 +19,6 @@ func parseResponseFetch() protocol.ParsePkgFn {
 			topicNum     int32
 			topicName    string
 			partitionNum int32
-			partition    int32
 			errorCode    int16
 		)
 
@@ -37,27 +36,30 @@ func parseResponseFetch() protocol.ParsePkgFn {
 			offset += 4 //session_id
 		}
 
-		if offset, err = message.ReadArraySize(offset, compact, &topicNum); err != nil || topicNum != 1 {
+		if offset, err = message.ReadArraySize(offset, compact, &topicNum); err != nil {
 			return false, true
 		}
 
-		if offset, err = message.ReadString(offset, compact, &topicName); err != nil {
-			return false, true
-		}
-
-		if offset, err = message.ReadArraySize(offset, compact, &partitionNum); err != nil || partitionNum != 1 {
-			return false, true
-		}
-		if offset, err = message.ReadInt32(offset, &partition); err != nil {
-			return false, true
-		}
-		if version < 7 {
-			if _, err = message.ReadInt16(offset, &errorCode); err != nil {
+		if topicNum > 0 {
+			if offset, err = message.ReadString(offset, compact, &topicName); err != nil {
 				return false, true
 			}
+
+			if version < 7 {
+				if offset, err = message.ReadArraySize(offset, compact, &partitionNum); err != nil {
+					return false, true
+				}
+				if partitionNum > 0 {
+					offset += 4
+					// Read ErrorCode in First Partition when version less than 7.
+					if _, err = message.ReadInt16(offset, &errorCode); err != nil {
+						return false, true
+					}
+				}
+			}
+			// Read First TopicName
+			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
-		message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
-		message.AddIntAttribute(constlabels.KafkaPartition, int64(partition))
 		message.AddIntAttribute(constlabels.KafkaErrorCode, int64(errorCode))
 		return true, true
 	}

--- a/collector/analyzer/network/protocol/kafka/kafka_response_fetch.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_response_fetch.go
@@ -57,11 +57,8 @@ func parseResponseFetch() protocol.ParsePkgFn {
 					}
 				}
 			}
-			/*
-				TODO Get all topicNames(Ver 0~12)
-				There is not enough cases to cover multi-topics, just read first topicName.
-				Since Version 13, topicName will be repalced with topicId as uuid, this will not got.
-			*/
+			// Get TopicName
+			// Since version 13, topicName will be repalced with topicId as uuid, therefore topicName is not able to be got.
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 		message.AddIntAttribute(constlabels.KafkaErrorCode, int64(errorCode))

--- a/collector/analyzer/network/protocol/kafka/kafka_response_fetch.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_response_fetch.go
@@ -57,7 +57,11 @@ func parseResponseFetch() protocol.ParsePkgFn {
 					}
 				}
 			}
-			// Read First TopicName
+			/*
+				TODO Get all topicNames(Ver 0~12)
+				There is not enough cases to cover multi-topics, just read first topicName.
+				Since Version 13, topicName will be repalced with topicId as uuid, this will not got.
+			*/
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 		message.AddIntAttribute(constlabels.KafkaErrorCode, int64(errorCode))

--- a/collector/analyzer/network/protocol/kafka/kafka_response_produce.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_response_produce.go
@@ -41,10 +41,7 @@ func parseResponseProduce() protocol.ParsePkgFn {
 					return false, true
 				}
 			}
-			/*
-				TODO Get all topicNames
-				There is not enough cases to cover multi-topics, just read first topicName.
-			*/
+			// Get topicName
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 		message.AddIntAttribute(constlabels.KafkaErrorCode, int64(errorCode))

--- a/collector/analyzer/network/protocol/kafka/kafka_response_produce.go
+++ b/collector/analyzer/network/protocol/kafka/kafka_response_produce.go
@@ -41,7 +41,10 @@ func parseResponseProduce() protocol.ParsePkgFn {
 					return false, true
 				}
 			}
-			// Read First TopicName
+			/*
+				TODO Get all topicNames
+				There is not enough cases to cover multi-topics, just read first topicName.
+			*/
 			message.AddUtf8StringAttribute(constlabels.KafkaTopic, topicName)
 		}
 		message.AddIntAttribute(constlabels.KafkaErrorCode, int64(errorCode))

--- a/collector/analyzer/network/protocol/protocol_parser.go
+++ b/collector/analyzer/network/protocol/protocol_parser.go
@@ -107,7 +107,7 @@ func (message PayloadMessage) HasAttribute(key string) bool {
 
 // =============== PayLoad ===============
 func (message *PayloadMessage) ReadUInt16(offset int) (complete bool, value uint16) {
-	if offset+2 >= len(message.Data) {
+	if offset+2 > len(message.Data) {
 		return true, 0
 	}
 	return false, uint16(message.Data[offset])<<8 | uint16(message.Data[offset+1])
@@ -117,7 +117,7 @@ func (message *PayloadMessage) ReadInt16(offset int, v *int16) (toOffset int, er
 	if offset < 0 {
 		return -1, ErrMessageInvalid
 	}
-	if offset+2 >= len(message.Data) {
+	if offset+2 > len(message.Data) {
 		return -1, ErrMessageShort
 	}
 	*v = int16(message.Data[offset])<<8 | int16(message.Data[offset+1])
@@ -128,7 +128,7 @@ func (message *PayloadMessage) ReadInt32(offset int, v *int32) (toOffset int, er
 	if offset < 0 {
 		return -1, ErrMessageInvalid
 	}
-	if offset+4 >= len(message.Data) {
+	if offset+4 > len(message.Data) {
 		return -1, ErrMessageShort
 	}
 	*v = int32(message.Data[offset])<<24 | int32(message.Data[offset+1])<<16 | int32(message.Data[offset+2])<<8 | int32(message.Data[offset+3])

--- a/collector/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-multi-topics.yml
+++ b/collector/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-multi-topics.yml
@@ -1,0 +1,58 @@
+trace:
+  key: fetch-one-topic-two-patitions
+  requests:
+    -
+      name: "writev"
+      timestamp: 100000000
+      user_attributes:
+        latency: 40000
+        res: 294
+        data:
+          - "000001220001000b0000b91d"
+          - "0010|consumer-merge-2"
+          - "ffffffff000001f400000001032000000019a9288c00003d5e00000003"
+          - "0011|npm_request_trace"
+          - "00000002000000010000001000000000027453beffffffffffffffff00100000000000040000001000000000029b41feffffffffffffffff00100000"
+          - "001b|npm_detail_topology_request"
+          - "0000000100000001000000100000000000fd2e3affffffffffffffff00100000"
+          - "001b|npm_detail_topology_connect"
+          - "000000020000000200000010000000000051527effffffffffffffff001000000000000500000010000000000108c878ffffffffffffffff00100000000000000000"
+  responses:
+    -
+      name: "read"
+      timestamp: 100020000
+      user_attributes:
+        latency: 3000
+        res: 22
+        data:
+          - "000000120000b91d00000000000019a9288c00000000"
+  expects:
+    -
+      Timestamp: 99960000
+      Values:
+        request_total_time: 60000
+        connect_time: 0
+        request_sent_time: 40000
+        waiting_ttfb_time: 17000
+        content_download_time: 3000
+        request_io: 294
+        response_io: 22
+      Labels:
+        pid: 925
+        src_ip: "127.0.0.1"
+        src_port: 38970
+        dst_ip: "127.0.0.1"
+        dst_port: 9092
+        dnat_ip: ""
+        dnat_port: -1
+        container_id: ""
+        is_slow: false
+        is_server: false
+        protocol: "kafka"
+        kafka_api: 1
+        kafka_version: 11
+        kafka_id: 47389
+        kafka_topic: "npm_request_trace"
+        kafka_error_code: 0
+        is_error: false
+        error_type: 0

--- a/collector/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-split.yml
+++ b/collector/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-split.yml
@@ -60,7 +60,6 @@ trace:
         kafka_version: 11
         kafka_id: 6801
         kafka_topic: "container-monitor"
-        kafka_partition: 0
         kafka_error_code: 0
         is_error: false
         error_type: 0

--- a/collector/analyzer/network/protocol/testdata/kafka/provider-trace-produce-split.yml
+++ b/collector/analyzer/network/protocol/testdata/kafka/provider-trace-produce-split.yml
@@ -59,7 +59,6 @@ trace:
         kafka_version: 7
         kafka_id: 64
         kafka_topic: "container-monitor"
-        kafka_partition: 0
         kafka_error_code: 0
         is_error: false
         error_type: 0


### PR DESCRIPTION
## Description
The kafka data is discerned as kafka and NOSUPPORT

## Motivation and Context
There is an strict requirements for only one topic with Kafka payload, but in fact there may be more than one.
When there is multi topics payload, the protocol is discerned as NOSUPPORT.

* When there is more than one topic, the topicName will take the first name based on following case:
    * The payload is substr with fixed length(1K), it's not able to get all topic names
    * If we get enough length for payload(Maybe 10K), the parser will take more performance cost
    * There is not enough cases to cover multi-topics
* The partition is not used, just remove it.

## How Has This Been Tested?
Run the unit test under `collector/analyzer/network` with `TestKafkaProtocol()` and the result is as follows.
```
=== RUN   TestKafkaProtocol
=== RUN   TestKafkaProtocol/produce-split
=== RUN   TestKafkaProtocol/fetch-split
=== RUN   TestKafkaProtocol/fetch-one-topic-two-patitions
--- PASS: TestKafkaProtocol (0.00s)
    --- PASS: TestKafkaProtocol/produce-split (0.00s)
    --- PASS: TestKafkaProtocol/fetch-split (0.00s)
    --- PASS: TestKafkaProtocol/fetch-one-topic-two-patitions (0.00s)
PASS
```