### PR TITLE
FIX Split HTTP Data is recognized as UNSUPPORT

### DIFF
--- a/collector/analyzer/network/network_analyzer_test.go
+++ b/collector/analyzer/network/network_analyzer_test.go
@@ -19,6 +19,7 @@ func TestHttpProtocol(t *testing.T) {
 	testProtocol(t, "http/server-event.yml",
 		"http/server-trace-slow.yml",
 		"http/server-trace-error.yml",
+		"http/server-trace-split.yml",
 		"http/server-trace-normal.yml")
 }
 

--- a/collector/analyzer/network/protocol/http/http_request.go
+++ b/collector/analyzer/network/protocol/http/http_request.go
@@ -30,7 +30,7 @@ func parseHttpRequest() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		offset, method := message.ReadUntilBlankWithLength(message.Offset, 8)
 
-		if !httpMethodsList[string(method)] || message.Data[offset-1] != ' ' || message.Data[offset] != '/' {
+		if !httpMethodsList[string(method)] {
 			if message.Data[offset-1] != ' ' || message.Data[offset] != '/' {
 				return false, true
 			}

--- a/collector/analyzer/network/protocol/testdata/http/server-trace-split.yml
+++ b/collector/analyzer/network/protocol/testdata/http/server-trace-split.yml
@@ -1,7 +1,7 @@
 trace:
   # 0--100--------------101 
   #     READ              WRITE
-  key: normal
+  key: split
   requests:
     -
       name: "read"

--- a/collector/analyzer/network/protocol/testdata/http/server-trace-split.yml
+++ b/collector/analyzer/network/protocol/testdata/http/server-trace-split.yml
@@ -1,0 +1,57 @@
+trace:
+  # 0--100--------------101 
+  #     READ              WRITE
+  key: normal
+  requests:
+    -
+      name: "read"
+      timestamp: 100000000
+      user_attributes:
+        latency: 5000
+        res: 191
+        data:
+          - "ET /test?sleep=0&respbyte=10&statusCode=200 HTTP/1.1\r\n"
+          - "Host: localhost:9001\r\n"
+          - "Us"
+  responses:
+    -
+      name: "write"
+      timestamp: 101000000
+      user_attributes:
+        latency: 40000
+        res: 135
+        data:
+          - "HTTP/1.1 200 OK\r\nDate: Thu, 30 Dec 2021 10:42:17 GMT\r\n"
+          - "Content-Length: 18\r\n"
+          - "Conten"
+  expects:
+    -
+      Timestamp: 99995000
+      Values:
+        request_total_time: 1005000
+        connect_time: 0
+        request_sent_time: 5000
+        waiting_ttfb_time: 960000
+        content_download_time: 40000
+        request_io: 191
+        response_io: 135
+      Labels:
+        pid: 12345
+        src_ip: "127.0.0.1"
+        src_port: 56266
+        dst_ip: "127.0.0.1"
+        dst_port: 9001
+        dnat_ip: ""
+        dnat_port: -1
+        container_id: ""
+        is_slow: false
+        is_server: true
+        protocol: "http"
+        is_error: false
+        error_type: 0
+        content_key: "/test"
+        http_method: "GET"
+        http_url: "/test?sleep=0&respbyte=10&statusCode=200"
+        http_status_code: 200
+        request_payload: "ET /test?sleep=0&respbyte=10&statusCode=200 HTTP/1.1\r\nHost: localhost:9001\r\nUs"
+        response_payload: "HTTP/1.1 200 OK\r\nDate: Thu, 30 Dec 2021 10:42:17 GMT\r\nContent-Length: 18\r\nConten"


### PR DESCRIPTION
## Description
HTTP Data with wrk bench is recognized as UNSUPPORT.
The data is sent with split 'G' and 'ET /xxx', where there is a response between two requests.

## Related Issue
#188

## Motivation and Context
FIX HTTP protocol recognization failure.

## How Has This Been Tested?
Add TestCase TestHttpProtocol/split in networkanalyzer_test.go
Run Test networkanalyzer_test.go
```
=== RUN   TestHttpProtocol
=== RUN   TestHttpProtocol/slowData
=== RUN   TestHttpProtocol/errorData
=== RUN   TestHttpProtocol/split
=== RUN   TestHttpProtocol/normal
--- PASS: TestHttpProtocol (0.00s)
    --- PASS: TestHttpProtocol/slowData (0.00s)
    --- PASS: TestHttpProtocol/errorData (0.00s)
    --- PASS: TestHttpProtocol/split (0.00s)
    --- PASS: TestHttpProtocol/normal (0.00s)
```