### PR TITLE
Rename metric rtt to srtt

### DIFF
--- a/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
+++ b/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
@@ -18,7 +18,7 @@ import (
 const (
 	TcpMetric analyzer.Type = "tcpmetricanalyzer"
 
-	TcpRttMetricName        = "kindling_tcp_rtt_microseconds"
+	TcpRttMetricName        = "kindling_tcp_srtt_microseconds"
 	TcpRetransmitMetricName = "kindling_tcp_retransmit_total"
 	TcpDropMetricName       = "kindling_tcp_packet_loss_total"
 )

--- a/collector/application/testdata/kindling-collector-config.yaml
+++ b/collector/application/testdata/kindling-collector-config.yaml
@@ -79,7 +79,7 @@ exporters:
       kindling_topology_request_request_bytes_total: 1
       kindling_topology_request_response_bytes_total: 1
       kindling_trace_request_duration_nanoseconds: 0
-      kindling_tcp_rtt_microseconds: 0
+      kindling_tcp_srtt_microseconds: 0
       kindling_tcp_retransmit_total: 1
       kindling_tcp_packet_loss_total: 1
       kindling_node_transmit_bytes_total: 1

--- a/collector/consumer/processor/aggregateprocessor/config.go
+++ b/collector/consumer/processor/aggregateprocessor/config.go
@@ -28,7 +28,7 @@ func NewDefaultConfig() *Config {
 			"request_io":  {{Kind: "sum"}},
 			"response_io": {{Kind: "sum"}},
 			// tcp
-			"kindling_tcp_rtt_microseconds":  {{Kind: "last"}},
+			"kindling_tcp_srtt_microseconds": {{Kind: "last"}},
 			"kindling_tcp_retransmit_total":  {{Kind: "sum"}},
 			"kindling_tcp_packet_loss_total": {{Kind: "sum"}},
 		},

--- a/collector/consumer/processor/aggregateprocessor/testdata/config.yaml
+++ b/collector/consumer/processor/aggregateprocessor/testdata/config.yaml
@@ -11,7 +11,7 @@ aggregate_kind_map:
     - kind: sum
   response_io:
     - kind: sum
-  kindling_tcp_rtt_microseconds:
+  kindling_tcp_srtt_microseconds:
     - kind: last
   kindling_tcp_retransmit_total:
     - kind: sum

--- a/collector/deploy/kindling-collector-config.yml
+++ b/collector/deploy/kindling-collector-config.yml
@@ -93,7 +93,7 @@ processors:
         - kind: sum
       response_io:
         - kind: sum
-      kindling_tcp_rtt_microseconds:
+      kindling_tcp_srtt_microseconds:
         - kind: last
       kindling_tcp_retransmit_total:
         - kind: sum
@@ -116,7 +116,7 @@ exporters:
       kindling_topology_request_request_bytes_total: 1
       kindling_topology_request_response_bytes_total: 1
       kindling_trace_request_duration_nanoseconds: 0
-      kindling_tcp_rtt_microseconds: 0
+      kindling_tcp_srtt_microseconds: 0
       kindling_tcp_retransmit_total: 1
       kindling_tcp_packet_loss_total: 1
     # Export data in the following ways: ["prometheus", "otlp", "stdout"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the metric name `kindling_tcp_rtt_microseconds` to `kindling_tcp_srtt_microseconds`.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
https://github.com/Kindling-project/kindling/issues/177#issuecomment-1104934291