### PR TITLE
Add is_error to aggregation key and add output metrics

### DIFF
--- a/collector/consumer/processor/aggregateprocessor/processor.go
+++ b/collector/consumer/processor/aggregateprocessor/processor.go
@@ -136,6 +136,7 @@ func newNetRequestLabelSelectors() *internal.LabelSelectors {
 		internal.LabelSelector{Name: constlabels.DstContainerId, VType: internal.StringType},
 		internal.LabelSelector{Name: constlabels.DstContainer, VType: internal.StringType},
 
+		internal.LabelSelector{Name: constlabels.IsError, VType: internal.BooleanType},
 		internal.LabelSelector{Name: constlabels.IsSlow, VType: internal.BooleanType},
 		internal.LabelSelector{Name: constlabels.HttpStatusCode, VType: internal.IntType},
 		internal.LabelSelector{Name: constlabels.DnsRcode, VType: internal.IntType},

--- a/collector/deploy/kindling-collector-config.yml
+++ b/collector/deploy/kindling-collector-config.yml
@@ -108,11 +108,13 @@ exporters:
   otelexporter:
     metric_aggregation_map:
       kindling_entity_request_total: 1
-      kindling_entity_request_duration_nanoseconds: 1
+      kindling_entity_request_duration_nanoseconds_total: 1
+      kindling_entity_request_average_duration_nanoseconds: 2
       kindling_entity_request_send_bytes_total: 1
       kindling_entity_request_receive_bytes_total: 1
       kindling_topology_request_total: 1
-      kindling_topology_request_duration_nanoseconds: 1
+      kindling_topology_request_duration_nanoseconds_total: 1
+      kindling_topology_request_average_duration_nanoseconds: 2
       kindling_topology_request_request_bytes_total: 1
       kindling_topology_request_response_bytes_total: 1
       kindling_trace_request_duration_nanoseconds: 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `is_error` to the aggregation key of `NetRequestGaugeGroup`and add the output metrics configuration missing before.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`is_error`