### PR TITLE
Increase labels key max size and add constraints

### DIFF
--- a/collector/consumer/processor/aggregateprocessor/internal/label_key.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/label_key.go
@@ -28,7 +28,8 @@ func NewLabelSelectors(selectors ...LabelSelector) *LabelSelectors {
 
 func (s *LabelSelectors) GetLabelKeys(labels *model.AttributeMap) *LabelKeys {
 	keys := &LabelKeys{}
-	for i, selector := range s.selectors {
+	for i := 0; i < maxLabelKeySize && i < len(s.selectors); i++ {
+		selector := s.selectors[i]
 		keys.keys[i].Name = selector.Name
 		keys.keys[i].VType = selector.VType
 		switch selector.VType {
@@ -43,7 +44,7 @@ func (s *LabelSelectors) GetLabelKeys(labels *model.AttributeMap) *LabelKeys {
 	return keys
 }
 
-const maxLabelKeySize = 34
+const maxLabelKeySize = 35
 
 type LabelKeys struct {
 	// LabelKeys will be used as key of map, so it is must be an array instead of a slice.

--- a/collector/consumer/processor/aggregateprocessor/internal/label_key_test.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/label_key_test.go
@@ -43,7 +43,7 @@ func TestLabelSelectors_GetLabelKeys(t *testing.T) {
 
 func TestLabelKeys_GetLabels(t *testing.T) {
 	type fields struct {
-		keys [34]LabelKey
+		keys [maxLabelKeySize]LabelKey
 	}
 	tests := []struct {
 		name   string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Increase aggregation labels key max size from 34 to 35.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We added a new label to the aggregation key in #191, but forgot to increase the max size of labels.