### PR TITLE
Add concurrency constraints to the defaultaggregator

### DIFF
--- a/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/default_aggregator.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/default_aggregator.go
@@ -12,8 +12,8 @@ import (
 //      GaugeGroup
 
 type DefaultAggregator struct {
-	recordersMap map[string]*valueRecorder
-	// mut is only used to make sure the access to the recordersMap is thread-safe.
+	recordersMap sync.Map
+	// mut is only used to make sure Dump the recorder is thread-safe.
 	// valueRecorder is responsible for its own thread-safe access.
 	mut    sync.RWMutex
 	config *AggregatedConfig
@@ -21,7 +21,7 @@ type DefaultAggregator struct {
 
 func NewDefaultAggregator(config *AggregatedConfig) *DefaultAggregator {
 	ret := &DefaultAggregator{
-		recordersMap: make(map[string]*valueRecorder),
+		recordersMap: sync.Map{},
 		config:       config,
 	}
 	return ret
@@ -29,36 +29,29 @@ func NewDefaultAggregator(config *AggregatedConfig) *DefaultAggregator {
 
 func (s *DefaultAggregator) Aggregate(g *model.GaugeGroup, selectors *internal.LabelSelectors) {
 	name := g.Name
-	s.mut.RLock()
-	recorder, ok := s.recordersMap[name]
-	s.mut.RUnlock()
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	recorder, ok := s.recordersMap.Load(name)
 	// Won't enter this branch too many times, as the recordersMap
 	// will become stable after running a period of time.
 	if !ok {
-		s.mut.Lock()
 		// double check to avoid double writing
-		recorder, ok = s.recordersMap[name]
-		if !ok {
-			recorder = newValueRecorder(name, s.config.KindMap)
-			s.recordersMap[name] = recorder
-		}
-		s.mut.Unlock()
+		recorder, _ = s.recordersMap.LoadOrStore(name, newValueRecorder(name, s.config.KindMap))
 	}
 	key := selectors.GetLabelKeys(g.Labels)
-	recorder.Record(key, g.Values, g.Timestamp)
-
-	// First copy the model.GaugeGroup, then output the result directly.
-	// Or first use intermediate struct, then generate the model.GaugeGroup.
+	recorder.(*valueRecorder).Record(key, g.Values, g.Timestamp)
 }
 
 func (s *DefaultAggregator) Dump() []*model.GaugeGroup {
 	ret := make([]*model.GaugeGroup, 0)
-	s.mut.RLock()
-	for _, v := range s.recordersMap {
-		ret = append(ret, v.dump()...)
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	s.recordersMap.Range(func(_, value interface{}) bool {
+		recorder := value.(*valueRecorder)
+		ret = append(ret, recorder.dump()...)
 		// Assume that the recordersMap will become stable after running a period of time.
-		v.reset()
-	}
-	s.mut.RUnlock()
+		recorder.reset()
+		return true
+	})
 	return ret
 }

--- a/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/default_aggregator.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/default_aggregator.go
@@ -29,8 +29,8 @@ func NewDefaultAggregator(config *AggregatedConfig) *DefaultAggregator {
 
 func (s *DefaultAggregator) Aggregate(g *model.GaugeGroup, selectors *internal.LabelSelectors) {
 	name := g.Name
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	recorder, ok := s.recordersMap.Load(name)
 	// Won't enter this branch too many times, as the recordersMap
 	// will become stable after running a period of time.

--- a/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/default_aggregator_test.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/default_aggregator_test.go
@@ -1,0 +1,78 @@
+package defaultaggregator
+
+import (
+	"github.com/Kindling-project/kindling/collector/consumer/processor/aggregateprocessor/internal"
+	"github.com/Kindling-project/kindling/collector/model"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestConcurrentAggregator(t *testing.T) {
+	aggKindMap := &AggregatedConfig{KindMap: map[string][]KindConfig{
+		"duration": {
+			{Kind: SumKind, OutputName: "duration_sum"},
+			{Kind: CountKind, OutputName: "request_count"},
+		},
+	}}
+
+	aggregator := NewDefaultAggregator(aggKindMap)
+	labels := model.NewAttributeMap()
+	labels.AddStringValue("key", "value")
+
+	labelSelectors := internal.NewLabelSelectors(
+		internal.LabelSelector{Name: "key", VType: internal.StringType},
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	stopCh := make(chan bool)
+
+	var runLoop = 2000
+	var duration int64 = 100
+	go func() {
+		for i := 0; i < runLoop; i++ {
+			gaugeValues := []*model.Gauge{
+				{"duration", duration},
+			}
+			gaugeGroup := model.NewGaugeGroup("testGauge", labels, 0, gaugeValues...)
+			aggregator.Aggregate(gaugeGroup, labelSelectors)
+			time.Sleep(time.Millisecond)
+		}
+		stopCh <- true
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	var durationSum int64
+	var requestCount int64
+	go func() {
+		ticker := time.NewTicker(200 * time.Millisecond)
+		for {
+			select {
+			case <-ticker.C:
+				ret := aggregator.Dump()
+				for _, g := range ret {
+					t.Log(g)
+					for _, v := range g.Values {
+						if v.Name == "duration_sum" {
+							durationSum += v.Value
+						} else if v.Name == "request_count" {
+							requestCount += v.Value
+						}
+					}
+
+				}
+			case <-stopCh:
+				wg.Done()
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	expectedDurationSum := int64(runLoop) * duration
+	expectedRequestCount := int64(runLoop)
+	if durationSum != expectedDurationSum || requestCount != expectedRequestCount {
+		t.Errorf("request_count = %v, duration_sum := %v", requestCount, durationSum)
+	}
+}

--- a/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/value_recorder.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/value_recorder.go
@@ -50,8 +50,8 @@ func (r *valueRecorder) Record(key *internal.LabelKeys, gaugeValues []*model.Gau
 // dump a set of metric from counter cache.
 // The return value holds the reference to the metric, not the copied one.
 func (r *valueRecorder) dump() []*model.GaugeGroup {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	ret := make([]*model.GaugeGroup, len(r.labelValues))
 	index := 0
 	for k, v := range r.labelValues {

--- a/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/value_recorder.go
+++ b/collector/consumer/processor/aggregateprocessor/internal/defaultaggregator/value_recorder.go
@@ -7,19 +7,16 @@ import (
 )
 
 type valueRecorder struct {
-	name        string
-	labelValues map[internal.LabelKeys]aggValuesMap
-	// mutex is only used to make sure the access to the labelValues is thread-safe.
+	name string
 	// aggValuesMap is responsible for its own thread-safe access.
-	mutex      sync.RWMutex
-	aggKindMap map[string][]KindConfig
+	labelValues sync.Map
+	aggKindMap  map[string][]KindConfig
 }
 
 func newValueRecorder(recorderName string, aggKindMap map[string][]KindConfig) *valueRecorder {
 	return &valueRecorder{
 		name:        recorderName,
-		labelValues: make(map[internal.LabelKeys]aggValuesMap),
-		mutex:       sync.RWMutex{},
+		labelValues: sync.Map{},
 		aggKindMap:  aggKindMap,
 	}
 }
@@ -29,41 +26,32 @@ func (r *valueRecorder) Record(key *internal.LabelKeys, gaugeValues []*model.Gau
 	if key == nil {
 		return
 	}
-	r.mutex.RLock()
-	aggValues, ok := r.labelValues[*key]
-	r.mutex.RUnlock()
+	aggValues, ok := r.labelValues.Load(*key)
 	if !ok {
-		r.mutex.Lock()
 		// double check to avoid double writing
-		aggValues, ok = r.labelValues[*key]
-		if !ok {
-			aggValues = newAggValuesMap(gaugeValues, r.aggKindMap)
-			r.labelValues[*key] = aggValues
-		}
-		r.mutex.Unlock()
+		aggValues, _ = r.labelValues.LoadOrStore(*key, newAggValuesMap(gaugeValues, r.aggKindMap))
 	}
 	for _, gauge := range gaugeValues {
-		aggValues.calculate(gauge.Name, gauge.Value, timestamp)
+		aggValues.(aggValuesMap).calculate(gauge.Name, gauge.Value, timestamp)
 	}
 }
 
 // dump a set of metric from counter cache.
 // The return value holds the reference to the metric, not the copied one.
 func (r *valueRecorder) dump() []*model.GaugeGroup {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	ret := make([]*model.GaugeGroup, len(r.labelValues))
-	index := 0
-	for k, v := range r.labelValues {
+	ret := make([]*model.GaugeGroup, 0)
+	r.labelValues.Range(func(key, value interface{}) bool {
+		k := key.(internal.LabelKeys)
+		v := value.(aggValuesMap)
 		gaugeGroup := model.NewGaugeGroup(r.name, k.GetLabels(), v.getTimestamp(), v.getAll()...)
-		ret[index] = gaugeGroup
-		index++
-	}
+		ret = append(ret, gaugeGroup)
+		return true
+	})
 	return ret
 }
 
+// reset the labelValues for further aggregation.
+// This method is not thread safe.
 func (r *valueRecorder) reset() {
-	r.mutex.Lock()
-	r.labelValues = make(map[internal.LabelKeys]aggValuesMap)
-	r.mutex.Unlock()
+	r.labelValues = sync.Map{}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. RLock when calling the `Aggregate()` method and lock when calling the `Dump()` method.
2. Use `sync.Map` to replace the native map with a mutex to improve readability.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#194 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the same test case with #194, and never see the error again.
=== RUN   TestConcurrentAggregator
--- PASS: TestConcurrentAggregator (1.66s)
PASS