### PR TITLE
FIX incorrect traceType for HTTP header parser

### DIFF
--- a/collector/analyzer/tools/traceid_parser.go
+++ b/collector/analyzer/tools/traceid_parser.go
@@ -3,23 +3,22 @@ package tools
 import "strings"
 
 func ParseTraceHeader(headers map[string]string) (traceType string, traceId string) {
-	if eagleEye, ok := headers["eagleeye-traceid"]; ok {
-		return "arms", eagleEye
-	}
-
 	if zipkin, ok := headers["x-b3-traceid"]; ok {
 		return "zipkin", zipkin
 	}
 
 	if jaeger, ok := headers["uber-trace-id"]; ok {
 		if pos := strings.Index(jaeger, ":"); pos > 0 {
-			return "zipkin", jaeger[0:pos]
+			return "jaeger", jaeger[0:pos]
 		}
-		return "zipkin", jaeger
+		return "jaeger", jaeger
 	}
 
-	if w3c, ok := headers["traceparent"]; ok && len(w3c) >= 32 {
-		return "w3c", w3c[3:32]
+	if w3c, ok := headers["traceparent"]; ok && len(w3c) >= 35 {
+		return "w3c", w3c[3:35]
+	}
+	if w3c, ok := headers["traceresponse"]; ok && len(w3c) >= 35 {
+		return "w3c", w3c[3:35]
 	}
 
 	return "", ""

--- a/collector/analyzer/tools/traceid_parser_test.go
+++ b/collector/analyzer/tools/traceid_parser_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import "testing"
+
+func TestParseTraceHeader(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		value     string
+		traceType string
+		traceId   string
+	}{
+		{name: "zipkin", key: "x-b3-traceid", value: "223f3b00a283c75c", traceType: "zipkin", traceId: "223f3b00a283c75c"},
+		{name: "jaeger", key: "uber-trace-id", value: "3997ed0a6a71f050:cf49be2de63d86e7:e02475aab05fd358:1", traceType: "jaeger", traceId: "3997ed0a6a71f050"},
+		{name: "w3c-request", key: "traceparent", value: "00-4bf92f3577b34da6a3ce929d0e0e4736-d75597dee50b0cac-00", traceType: "w3c", traceId: "4bf92f3577b34da6a3ce929d0e0e4736"},
+		{name: "w3c-response", key: "traceresponse", value: "00-4bf92f3577b34da6a3ce929d0e0e4736-828c5d0d435ba505-01", traceType: "w3c", traceId: "4bf92f3577b34da6a3ce929d0e0e4736"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := map[string]string{
+				tt.key: tt.value,
+			}
+
+			traceType, traceId := ParseTraceHeader(headers)
+			if traceType != tt.traceType {
+				t.Errorf("Fail to check traceType, got = %s, want %s", traceType, tt.traceType)
+			}
+
+			if traceId != tt.traceId {
+				t.Errorf("Fail to check traceId, got = %s, want %s", traceId, tt.traceId)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
FIX incorrect traceType for HTTP header parser.

## Motivation and Context
Fix following bugs for parsing traceId header.
* HTTP header with uber-trace-id is set to zipkin, but it was jaeger.
* HTTP header with traceparent got incomplete traceid

Besides, add more cases for parsing traceId header.
* w3c response header

Remove the following case when parsing traceId header.
* Eagleeye

## How Has This Been Tested?
Run TestCase ParseTraceHeader in tools/traceid_parser_test.go
Run Test traceid_parser_test.go
```
=== RUN   TestParseTraceHeader
=== RUN   TestParseTraceHeader/zipkin
=== RUN   TestParseTraceHeader/jaeger
=== RUN   TestParseTraceHeader/w3c-request
=== RUN   TestParseTraceHeader/w3c-response
--- PASS: TestParseTraceHeader (0.00s)
    --- PASS: TestParseTraceHeader/zipkin (0.00s)
    --- PASS: TestParseTraceHeader/jaeger (0.00s)
    --- PASS: TestParseTraceHeader/w3c-request (0.00s)
    --- PASS: TestParseTraceHeader/w3c-response (0.00s)
PASS
```