### PR TITLE
Fix: convert stopped when list is full

### DIFF
--- a/probe/src/probe/publisher/publisher.cpp
+++ b/probe/src/probe/publisher/publisher.cpp
@@ -53,9 +53,7 @@ void publisher::consume_sysdig_event(sinsp_evt *evt, int pid, converter *sysdigC
         if (sysdigConverter->judge_max_size()) {
             // check if the send list has sent
             if (!m_ready[kindlingEventList]) {
-                kindlingEventList = sysdigConverter->swap_list(kindlingEventList);
-                m_kindlingEventLists[sysdigConverter] = kindlingEventList;
-                m_ready[kindlingEventList] = true;
+                swap_list(sysdigConverter, kindlingEventList);
             } else {
                 // drop event
                 return;
@@ -65,9 +63,7 @@ void publisher::consume_sysdig_event(sinsp_evt *evt, int pid, converter *sysdigC
         sysdigConverter->convert(evt);
         // if send list was sent
         if (sysdigConverter->judge_batch_size() && !m_ready[kindlingEventList]) {
-            kindlingEventList = sysdigConverter->swap_list(kindlingEventList);
-            m_kindlingEventLists[sysdigConverter] = kindlingEventList;
-            m_ready[kindlingEventList] = true;
+            swap_list(sysdigConverter, kindlingEventList);
         }
     }
 }
@@ -168,6 +164,11 @@ void publisher::subscribe(string sub_event, string &reason) {
     m_bind_address->insert((char *) address.data(), socket);
 }
 
+void publisher::swap_list(converter *cvt, KindlingEventList* kindlingEventList) {
+    kindlingEventList = cvt->swap_list(kindlingEventList);
+    m_kindlingEventLists[cvt] = kindlingEventList;
+    m_ready[kindlingEventList] = true;
+}
 
 selector::selector(sinsp *inspector) {
     m_labels = new map<ppm_event_type, vector<Category>* >;

--- a/probe/src/probe/publisher/publisher.cpp
+++ b/probe/src/probe/publisher/publisher.cpp
@@ -52,12 +52,11 @@ void publisher::consume_sysdig_event(sinsp_evt *evt, int pid, converter *sysdigC
 
         if (sysdigConverter->judge_max_size()) {
             // check if the send list has sent
-            if (!m_ready[kindlingEventList]) {
-                swap_list(sysdigConverter, kindlingEventList);
-            } else {
+            if (m_ready[kindlingEventList]) {
                 // drop event
                 return;
             }
+            swap_list(sysdigConverter, kindlingEventList);
         }
 
         sysdigConverter->convert(evt);

--- a/probe/src/probe/publisher/publisher.h
+++ b/probe/src/probe/publisher/publisher.h
@@ -51,6 +51,8 @@ private:
     void subscribe(string sub_event, string &reason);
     void unsubscribe(string sub_event);
 
+    void swap_list(converter *cvt, KindlingEventList* kindlingEventList);
+
     // single sender
     Socket m_socket;
     map<converter *, KindlingEventList *> m_kindlingEventLists;


### PR DESCRIPTION
## Related Issue
#197 

## Motivation and Context
fix: convert stopped when list is full

## How Has This Been Tested?
1. set list_max_size to X
2. make the convert list size to X continuously
3. check the convert part is running normally and the max size of convert list is X.