### PR TITLE
Remove unused selectors of TCP metrics when aggregating

### DIFF
--- a/collector/consumer/exporter/otelexporter/instrument.go
+++ b/collector/consumer/exporter/otelexporter/instrument.go
@@ -185,8 +185,6 @@ func newTcpRttMicroSecondsSelectors() *aggregator.LabelSelectors {
 		aggregator.LabelSelector{Name: constlabels.DstService, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstIp, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstPort, VType: aggregator.IntType},
-		aggregator.LabelSelector{Name: constlabels.DnatIp, VType: aggregator.StringType},
-		aggregator.LabelSelector{Name: constlabels.DnatPort, VType: aggregator.IntType},
 		aggregator.LabelSelector{Name: constlabels.DstContainerId, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstContainer, VType: aggregator.StringType},
 	)

--- a/collector/consumer/processor/aggregateprocessor/processor.go
+++ b/collector/consumer/processor/aggregateprocessor/processor.go
@@ -169,8 +169,6 @@ func newTcpLabelSelectors() *aggregator.LabelSelectors {
 		aggregator.LabelSelector{Name: constlabels.DstService, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstIp, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstPort, VType: aggregator.IntType},
-		aggregator.LabelSelector{Name: constlabels.DnatIp, VType: aggregator.StringType},
-		aggregator.LabelSelector{Name: constlabels.DnatPort, VType: aggregator.IntType},
 		aggregator.LabelSelector{Name: constlabels.DstContainerId, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstContainer, VType: aggregator.StringType},
 	)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove unused selectors of TCP metrics when aggregating.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since the fields `dnat_ip` and `dnat_port` are removed after passing through `k8sprocessor`, we could safely remove them at `aggregatorprocessor` and `otelexporter`. Otherwise, the output metrics will always contain a label of `dnat_port` with 0.

> kindling_tcp_srtt_microseconds{**dnat_port="0"**,dst_container="alertmanager",dst_ip="192.168.200.200",dst_namespace="monitoring",dst_node="work-153",dst_node_ip="10.10.102.153",dst_pod="alertmanager-main-1",dst_port="9093",dst_workload_kind="statefulset",dst_workload_name="alertmanager-main",instance="10.10.102.153:9500",job="kindling",service_instance_id="work-153",service_name="cmonitor-noclusteridset",src_container="rules-configmap-reloader",src_ip="192.168.200.208",src_namespace="monitoring",src_node="work-153",src_node_ip="10.10.102.153",src_pod="prometheus-k8s-0",src_port="0",src_service="prometheus-operated",src_workload_kind="statefulset",src_workload_name="prometheus-k8s"}

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The output metrics don't contain the label `dnat_port` anymore. And no other areas of the code are affected.
After fixing this problem, the metrics with label `dnat_port` are gone.
![image](https://user-images.githubusercontent.com/46807570/166901060-94f91255-ebdb-4ab4-b1d2-10953425c443.png)
![image](https://user-images.githubusercontent.com/46807570/166901259-1d79cb59-f0b8-4cd5-8c41-dc4abd463a72.png)
