### PR TITLE
Print probe version

### DIFF
--- a/probe/src/probe/BUILD.bazel
+++ b/probe/src/probe/BUILD.bazel
@@ -81,9 +81,9 @@ container_push(
     format = "Docker",
     image = ":kindling_probe_image",
     # ATTENTION!! Modify this if you want to change docker registry.
-    registry = "docker.io",
-    repository = "kindlingproject/kindling-probe",
-    tag = "latest",
+    registry = "registry.cn-hangzhou.aliyuncs.com",
+    repository = "sugary199/kindling-probe",
+    tag = "version1",
 )
 
 container_push(
@@ -91,7 +91,7 @@ container_push(
     format = "Docker",
     image = ":kindling_probe_image_localdriver",
     # ATTENTION!! Modify this if you want to change docker registry.
-    registry = "docker.io",
-    repository = "kindlingproject/kindling-probe",
-    tag = "latest",
+    registry = "registry.cn-hangzhou.aliyuncs.com",
+    repository = "sugary199/kindling-probe",
+    tag = "version1",
 )

--- a/probe/src/probe/BUILD.bazel
+++ b/probe/src/probe/BUILD.bazel
@@ -80,18 +80,18 @@ container_push(
     name = "push_image",
     format = "Docker",
     image = ":kindling_probe_image",
-    # ATTENTION!! Modify this if you want to change docker registry.
-    registry = "registry.cn-hangzhou.aliyuncs.com",
-    repository = "sugary199/kindling-probe",
-    tag = "version1",
+    # ATTENTION!! Modify this if you want to change docker registry.    
+    registry = "docker.io",
+    repository = "kindlingproject/kindling-probe",
+    tag = "latest",
 )
 
 container_push(
     name = "push_image_localdriver",
     format = "Docker",
     image = ":kindling_probe_image_localdriver",
-    # ATTENTION!! Modify this if you want to change docker registry.
-    registry = "registry.cn-hangzhou.aliyuncs.com",
-    repository = "sugary199/kindling-probe",
-    tag = "version1",
+    # ATTENTION!! Modify this if you want to change docker registry.    
+    registry = "docker.io",
+    repository = "kindlingproject/kindling-probe",
+    tag = "latest",
 )

--- a/probe/src/probe/BUILD.bazel
+++ b/probe/src/probe/BUILD.bazel
@@ -80,7 +80,7 @@ container_push(
     name = "push_image",
     format = "Docker",
     image = ":kindling_probe_image",
-    # ATTENTION!! Modify this if you want to change docker registry.    
+    # ATTENTION!! Modify this if you want to change docker registry.
     registry = "docker.io",
     repository = "kindlingproject/kindling-probe",
     tag = "latest",
@@ -90,7 +90,7 @@ container_push(
     name = "push_image_localdriver",
     format = "Docker",
     image = ":kindling_probe_image_localdriver",
-    # ATTENTION!! Modify this if you want to change docker registry.    
+    # ATTENTION!! Modify this if you want to change docker registry.
     registry = "docker.io",
     repository = "kindlingproject/kindling-probe",
     tag = "latest",

--- a/probe/src/probe/main.cpp
+++ b/probe/src/probe/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     output_format = "*%evt.num %evt.outputtime %evt.cpu %container.name (%container.id) %proc.name (%thread.tid:%thread.vtid) %evt.dir %evt.type %evt.info";
 
     LOG(INFO) << "Start kindling probe...";
-    LOG(INFO) << "KINDLING_PROBE_VERSION: " << KINDLING_PROBE_VERSION;
+    //LOG(INFO) << "KINDLING_PROBE_VERSION: " << KINDLING_PROBE_VERSION;
     LOG(INFO) << "KINDLING_PROBE_"<< _VERSION_ ;
     std::cout << "KINDLING_PROBE_"<< _VERSION_ << std::endl;
 

--- a/probe/src/probe/main.cpp
+++ b/probe/src/probe/main.cpp
@@ -110,7 +110,6 @@ int main(int argc, char** argv) {
     output_format = "*%evt.num %evt.outputtime %evt.cpu %container.name (%container.id) %proc.name (%thread.tid:%thread.vtid) %evt.dir %evt.type %evt.info";
 
     LOG(INFO) << "Start kindling probe...";
-    //LOG(INFO) << "KINDLING_PROBE_VERSION: " << KINDLING_PROBE_VERSION;
     LOG(INFO) << "KINDLING_PROBE_"<< _VERSION_ ;
     std::cout << "KINDLING_PROBE_"<< _VERSION_ << std::endl;
 

--- a/probe/src/probe/main.cpp
+++ b/probe/src/probe/main.cpp
@@ -12,6 +12,9 @@
 #include "src/common/base/base.h"
 #include "src/probe/catch_sig.h"
 
+#include "src/probe/version.h"
+#include <ctime>
+#include <string>
 
 DEFINE_int32(sysdig_snaplen, 80, "The len of one sysdig event");
 DEFINE_int32(list_batch_size, 100, "The batch size of convert/send list");
@@ -108,6 +111,9 @@ int main(int argc, char** argv) {
 
     LOG(INFO) << "Start kindling probe...";
     LOG(INFO) << "KINDLING_PROBE_VERSION: " << KINDLING_PROBE_VERSION;
+    LOG(INFO) << "KINDLING_PROBE_"<< _VERSION_ ;
+    std::cout << "KINDLING_PROBE_"<< _VERSION_ << std::endl;
+
     TerminationHandler::InstallSignalHandlers();
     try {
         inspector = new sinsp();

--- a/probe/src/probe/probe-build.sh
+++ b/probe/src/probe/probe-build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+commit_ts=`git log -1 --format="%ct"`
+commit_time=`date -d@$commit_ts +"%Y-%m-%d %H:%M:%S"`
+current_time=`date +"%Y-%m-%d %H:%M:%S"`
+git_version=`git log -1 --format="%h"`
+sed  s/MYVERSION/"version: $git_version commit: $commit_time build: $current_time"/g version.h.tmp > version.h
+echo "Git commit:" $commit_ts
+

--- a/probe/src/probe/version.h
+++ b/probe/src/probe/version.h
@@ -1,0 +1,3 @@
+#ifndef _VERSION_
+#define _VERSION_ "version: 48381d3 commit: 2022-04-26 17:37:44 build: 2022-04-27 23:42:56"
+#endif

--- a/probe/src/probe/version.h.tmp
+++ b/probe/src/probe/version.h.tmp
@@ -1,0 +1,3 @@
+#ifndef _VERSION_
+#define _VERSION_ "MYVERSION"
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Print probe version in both terminal and log. 
## Description
<!--- Describe your changes in detail -->
Generated a header file `version.h`with `probe-build.sh`
Reference it and output in the main function
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
https://github.com/Kindling-project/kindling/issues/112
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
you can see that in probe container terminal
```
KINDLING_PROBE_version: 48381d3 commit: 2022-04-26 17:37:44 build: 2022-04-27 23:42:56
```