### PR TITLE
Fix hostport not processed in k8sprocessor 

### DIFF
--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -124,6 +124,10 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 	} else if resInfo, ok := p.metadata.GetContainerByIpPort(dstIp, uint32(dstPort)); ok {
 		// DstIp is IP of a container
 		addContainerMetaInfoLabelDST(labelMap, resInfo)
+	} else if resInfo, ok := p.metadata.GetContainerByHostIpPort(dstIp, uint32(dstPort)); ok {
+		addContainerMetaInfoLabelDST(labelMap, resInfo)
+		labelMap.UpdateAddStringValue(constlabels.DstIp, resInfo.RefPodInfo.Ip)
+		labelMap.UpdateAddIntValue(constlabels.DstPort, int64(resInfo.HostPortMap[int32(dstPort)]))
 	} else {
 		// DstIp is a IP from external
 		if nodeName, ok := p.metadata.GetNodeNameByIp(dstIp); ok {

--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Kindling-project/kindling/collector/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/model/constnames"
 	"go.uber.org/zap"
+	"strconv"
 )
 
 const (
@@ -128,6 +129,7 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 		addContainerMetaInfoLabelDST(labelMap, resInfo)
 		labelMap.UpdateAddStringValue(constlabels.DstIp, resInfo.RefPodInfo.Ip)
 		labelMap.UpdateAddIntValue(constlabels.DstPort, int64(resInfo.HostPortMap[int32(dstPort)]))
+		labelMap.UpdateAddStringValue(constlabels.DstService, dstIp+":"+strconv.Itoa(int(dstPort)))
 	} else {
 		// DstIp is a IP from external
 		if nodeName, ok := p.metadata.GetNodeNameByIp(dstIp); ok {

--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -280,6 +280,14 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 		return
 	}
 
+	dstContainerInfo, ok = p.metadata.GetContainerByHostIpPort(dstIp, uint32(dstPort))
+	if ok {
+		addContainerMetaInfoLabelDST(labelMap, dstContainerInfo)
+		labelMap.UpdateAddStringValue(constlabels.DstIp, dstContainerInfo.RefPodInfo.Ip)
+		labelMap.UpdateAddIntValue(constlabels.DstPort, int64(dstContainerInfo.HostPortMap[int32(dstPort)]))
+		labelMap.UpdateAddStringValue(constlabels.DstService, dstIp+":"+strconv.Itoa(int(dstPort)))
+	}
+
 	dstPodInfo, ok := p.metadata.GetPodByIp(dstIp)
 	if ok {
 		addPodMetaInfoLabelDST(labelMap, dstPodInfo)

--- a/collector/metadata/kubernetes/hostport_map.go
+++ b/collector/metadata/kubernetes/hostport_map.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import "sync"
+
+type IpPortKey struct {
+	Ip   string
+	Port uint32
+}
+
+type HostPortMap struct {
+	hostPortInfo sync.Map
+}
+
+func newHostPortMap() *HostPortMap {
+	return &HostPortMap{
+		hostPortInfo: sync.Map{},
+	}
+}
+
+func (m *HostPortMap) add(ip string, port uint32, containerInfo *K8sContainerInfo) {
+	key := IpPortKey{ip, port}
+	m.hostPortInfo.Store(key, containerInfo)
+}
+
+func (m *HostPortMap) get(ip string, port uint32) (*K8sContainerInfo, bool) {
+	key := IpPortKey{ip, port}
+	containerInfo, ok := m.hostPortInfo.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return containerInfo.(*K8sContainerInfo), true
+}
+
+func (m *HostPortMap) delete(ip string, port uint32) {
+	key := IpPortKey{ip, port}
+	m.hostPortInfo.Delete(key)
+}

--- a/collector/metadata/kubernetes/pod_delete.go
+++ b/collector/metadata/kubernetes/pod_delete.go
@@ -19,7 +19,7 @@ type deleteRequest struct {
 	ts  time.Time
 }
 
-// deleteLoop deletes pods from cache priodically.
+// deleteLoop deletes pods from cache periodically.
 func podDeleteLoop(interval time.Duration, gracePeriod time.Duration, stopCh chan struct{}) {
 	// This loop runs after N seconds and deletes pods from cache.
 	// It iterates over the delete queue and deletes all that aren't
@@ -63,6 +63,10 @@ func deletePod(pod *corev1.Pod) {
 		for _, port := range container.Ports {
 			// Assume that PodIP:Port can't be reused in a few seconds
 			MetaDataCache.DeleteContainerByIpPort(pod.Status.PodIP, uint32(port.ContainerPort))
+			// If hostPort is specified, add the container using HostIP and HostPort
+			if port.HostPort != 0 {
+				MetaDataCache.DeleteContainerByHostIpPort(pod.Status.HostIP, uint32(port.HostPort))
+			}
 		}
 	}
 }

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -29,7 +29,7 @@ type PodInfo struct {
 type podMap struct {
 	// namespace:
 	//   podName: podInfo{}
-	info  map[string]map[string]*PodInfo
+	Info  map[string]map[string]*PodInfo
 	mutex sync.RWMutex
 }
 
@@ -38,25 +38,25 @@ var podUpdateMutex sync.Mutex
 
 func newPodMap() *podMap {
 	return &podMap{
-		info:  make(map[string]map[string]*PodInfo),
+		Info:  make(map[string]map[string]*PodInfo),
 		mutex: sync.RWMutex{},
 	}
 }
 
 func (m *podMap) add(info *PodInfo) {
 	m.mutex.Lock()
-	podInfoMap, ok := m.info[info.Namespace]
+	podInfoMap, ok := m.Info[info.Namespace]
 	if !ok {
 		podInfoMap = make(map[string]*PodInfo)
 	}
 	podInfoMap[info.Name] = info
-	m.info[info.Namespace] = podInfoMap
+	m.Info[info.Namespace] = podInfoMap
 	m.mutex.Unlock()
 }
 
 func (m *podMap) delete(namespace string, name string) {
 	m.mutex.Lock()
-	podInfoMap, ok := m.info[namespace]
+	podInfoMap, ok := m.Info[namespace]
 	if ok {
 		delete(podInfoMap, name)
 	}
@@ -66,7 +66,7 @@ func (m *podMap) delete(namespace string, name string) {
 func (m *podMap) get(namespace string, name string) (*PodInfo, bool) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	podInfoMap, ok := m.info[namespace]
+	podInfoMap, ok := m.Info[namespace]
 	if !ok {
 		return nil, false
 	}
@@ -86,7 +86,7 @@ func (m *podMap) getPodsMatchSelectors(namespace string, selectors map[string]st
 	}
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	podInfoMap, ok := m.info[namespace]
+	podInfoMap, ok := m.Info[namespace]
 	if !ok {
 		return retPodInfoSlice
 	}

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -217,6 +217,10 @@ func onAdd(obj interface{}) {
 			}
 			for _, port := range tmpContainer.Ports {
 				pI.Ports = append(pI.Ports, port.ContainerPort)
+				// If hostPort is specified, add the container using HostIP and HostPort
+				if port.HostPort != 0 {
+					MetaDataCache.AddContainerByIpPort(pod.Status.HostIP, uint32(port.HostPort), containerInfo)
+				}
 				MetaDataCache.AddContainerByIpPort(pod.Status.PodIP, uint32(port.ContainerPort), containerInfo)
 			}
 		}

--- a/collector/metadata/kubernetes/pod_watch_test.go
+++ b/collector/metadata/kubernetes/pod_watch_test.go
@@ -28,7 +28,7 @@ func TestTruncateContainerId(t *testing.T) {
 
 func TestOnAdd(t *testing.T) {
 	globalPodInfo = &podMap{
-		info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*PodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),
@@ -51,7 +51,7 @@ func TestOnAdd(t *testing.T) {
 
 func TestOnAddLowercaseWorkload(t *testing.T) {
 	globalPodInfo = &podMap{
-		info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*PodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),

--- a/collector/metadata/kubernetes/service_watch_test.go
+++ b/collector/metadata/kubernetes/service_watch_test.go
@@ -116,7 +116,7 @@ func TestServiceMap_GetServiceMatchLabels(t *testing.T) {
 
 func TestOnAddService(t *testing.T) {
 	globalPodInfo = &podMap{
-		info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*PodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),
@@ -139,7 +139,7 @@ func TestOnAddService(t *testing.T) {
 
 func TestServiceMap_Delete(t *testing.T) {
 	globalPodInfo = &podMap{
-		info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*PodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Record containers using hostPort as a new map used for searching pod information when the destination is in hostIp:hostPort format.
2. The method `GetDNATTuple` in the conntracker module returned both `DNAT` and `SNAT` connections before. This PR fixes this bug. This bug could bring unexpected `dst_ip` and `dst_port` labels when we get `SNAT` connections from the method `GetDNATTuple` incorrectly. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
What we expect to see for the metric labels of `hostPort` scenario is:
1. `dst_ip` is the pod's IP.
2. `dst_port` is the container's port that is exposed to the hostport.
3. `dst_service` should be `hostIP:hostPort` which represents how the pod is called.

The scenario of containers using hostPort was not considered before, so when a client calls a pod using HostIP:HostPort, the processed data didn't contain the information of the pod. This PR resolves such a problem by recording the `hostPorts` as a new map and looking up the map for the container's metadata.

### `GetDNATTuple` bug
```
tcp      6 83 TIME_WAIT 
(Send)src=192.168.94.121 dst=10.10.101.124 sport=33532 dport=18080 
(Reply)src=10.10.101.124 dst=10.10.103.96 sport=18080 dport=33532 [ASSURED] 
mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=1
```
This is one record shown by executing `conntrack -L`. 
- 192.168.94.121 is the IP of a Pod named `A`.
- 10.10.101.124 is the host IP of another Pod named `B`.
- 18080 is the `hostPort` of the Pod `B`.
- 10.10.103.96 is the host IP of the Pod `A`.

Since `Send.dst` == `Reply.src` and `Send.dport` == `Reply.sport`, we know there is no `DNAT` happened. But because `Send.src` != `Reply.Dst`, `SNAT` happened. This record was returned by the method `GetDNATTuple` before, which resulted in incorrect value in `dnat_ip` and `dnat_port` fields with the following piece of codes.

```go
	if nil != mps.natTuple && mps.responses != nil {
		labels.UpdateAddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
		labels.UpdateAddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
	}

```

Considering that we replace `dst_ip` and `dst_port` with `dnat_ip` and `dnat_port` in the adapters of `otelexporter`, if the fields `dnat_ip` and `dnat_port` are incorrect, the same `dst_ip` and `dst_port` will be.

```go
func replaceDstIpOrDstPortByDNat() adjustFunctions {
	return adjustFunctions{
		adjustAttrMaps: func(labels *model.AttributeMap, attributeMap *model.AttributeMap) *model.AttributeMap {
			dNatIp := labels.GetStringValue(constlabels.DnatIp)
			dNatPort := labels.GetIntValue(constlabels.DnatPort)
			if dNatIp == "" || dNatPort < 1 {
				return attributeMap
			} else {
				attributeMap.AddStringValue(constlabels.DstIp, dNatIp)
				attributeMap.AddIntValue(constlabels.DstPort, dNatPort)
				return attributeMap
			}
		},
        ....
}
```
Until here it looks like the problem is not serious, because if no `DNAT` happened, `dnat_ip` should always equal to `dst_ip`. There is no effect even if we replace `dst_ip` with the same `dnat_ip`. But when it comes to `hostPort`, everything changes.

When a pod is called via `hostIP:hostPort`, the original `dst_ip` is `hostIP` and the original `dst_port` is `hostPort`. In this PR, we replace `dst_ip`(hostIP) and `dst_port`(hostPort) with its pod's IP and container's port. If they are replaced by `dnat_ip` and `dnat_port` again, the final result will be not expected.